### PR TITLE
Fixed some problems with the GameController project.

### DIFF
--- a/Apps/GameController/GameController.vcproj
+++ b/Apps/GameController/GameController.vcproj
@@ -203,7 +203,7 @@
 		</Configuration>
 		<Configuration
 			Name="Release|Win32"
-			OutputDirectory="$(SolutionDir)"
+			OutputDirectory="release\"
 			IntermediateDirectory="release\"
 			ConfigurationType="1"
 			UseOfMFC="0"

--- a/Apps/GameController/GameController.vcproj
+++ b/Apps/GameController/GameController.vcproj
@@ -77,10 +77,10 @@
 				Name="VCLinkerTool"
 				IgnoreImportLibrary="true"
 				AdditionalOptions="&quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot;"
-				AdditionalDependencies="$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\qtmaind.lib $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\QtGuid4.lib $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\QtCored4.lib libowlsock.lib"
+				AdditionalDependencies="$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\qtmaind.lib $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\QtGuid4.lib $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib\QtCored4.lib"
 				OutputFile="$(OutDir)\GameController.exe"
 				SuppressStartupBanner="true"
-				AdditionalLibraryDirectories="..\..\LSL\liblsl\bin;&quot;$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib&quot;;&quot;$(BOOST_ROOT)\lib&quot;"
+				AdditionalLibraryDirectories="..\..\LSL\liblsl\bin;&quot;$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib&quot;;&quot;$(BOOST_ROOT)\lib&quot;;$(DXSDK_DIR)\lib\x86"
 				GenerateDebugInformation="true"
 				ProgramDatabaseFile=""
 				SubSystem="2"
@@ -106,6 +106,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				CommandLine="xcopy ..\..\LSL\liblsl\bin\liblsl32.dll $(TargetDir) /Y /F&#x0D;&#x0A;xcopy $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\bin\QtCored4.dll $(TargetDir) /Y /F&#x0D;&#x0A;xcopy $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\bin\QtGuid4.dll $(TargetDir) /Y /F"
 			/>
 		</Configuration>
 		<Configuration
@@ -168,7 +169,7 @@
 				Name="VCLinkerTool"
 				IgnoreImportLibrary="true"
 				AdditionalOptions="&quot;/MANIFESTDEPENDENCY:type=&apos;win32&apos; name=&apos;Microsoft.Windows.Common-Controls&apos; version=&apos;6.0.0.0&apos; publicKeyToken=&apos;6595b64144ccf1df&apos; language=&apos;*&apos; processorArchitecture=&apos;*&apos;&quot;"
-				AdditionalDependencies="c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\qtmaind.lib c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\QtGuid4.lib c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\QtCored4.lib libowlsock.lib"
+				AdditionalDependencies="c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\qtmaind.lib c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\QtGuid4.lib c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib\QtCored4.lib"
 				OutputFile="$(OutDir)\PhaseSpace.exe"
 				SuppressStartupBanner="true"
 				AdditionalLibraryDirectories="..\..\LSL\liblsl\bin;c:\DEVEL\QtSDK\Desktop\Qt\4.8.1\msvc2008\lib;..\..\..\..\boost_1_47\lib"
@@ -263,7 +264,7 @@
 				OutputFile="$(OutDir)\GameController.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
-				AdditionalLibraryDirectories="..\..\LSL\liblsl\bin;&quot;$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib&quot;;&quot;$(BOOST_ROOT)\lib&quot;"
+				AdditionalLibraryDirectories="..\..\LSL\liblsl\bin;&quot;$(QTSDK)\Desktop\Qt\4.8.1\msvc2008\lib&quot;;&quot;$(BOOST_ROOT)\lib&quot;;$(DXSDK_DIR)\lib\x86"
 				IgnoreAllDefaultLibraries="false"
 				GenerateDebugInformation="false"
 				ProgramDatabaseFile=""
@@ -290,6 +291,7 @@
 			/>
 			<Tool
 				Name="VCPostBuildEventTool"
+				CommandLine="xcopy ..\..\LSL\liblsl\bin\liblsl32.dll $(TargetDir) /Y /F&#x0D;&#x0A;xcopy $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\bin\QtCore4.dll $(TargetDir) /Y /F&#x0D;&#x0A;xcopy $(QTSDK)\Desktop\Qt\4.8.1\msvc2008\bin\QtGui4.dll $(TargetDir) /Y /F"
 			/>
 		</Configuration>
 		<Configuration
@@ -471,7 +473,27 @@
 				RelativePath="release\moc_mainwindow.cpp"
 				>
 				<FileConfiguration
+					Name="Debug|Win32"
+					ExcludedFromBuild="true"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+					/>
+				</FileConfiguration>
+				<FileConfiguration
 					Name="Debug|x64"
+					ExcludedFromBuild="true"
+					>
+					<Tool
+						Name="VCCLCompilerTool"
+					/>
+				</FileConfiguration>
+			</File>
+			<File
+				RelativePath=".\debug\moc_mainwindow.cpp"
+				>
+				<FileConfiguration
+					Name="Release|Win32"
 					ExcludedFromBuild="true"
 					>
 					<Tool

--- a/Apps/GameController/mainwindow.cpp
+++ b/Apps/GameController/mainwindow.cpp
@@ -385,7 +385,7 @@ void MainWindow::read_thread(std::string name) {
 		float sample[36] = {js.lX,js.lY,js.lZ,js.lRx,js.lRy,js.lRz,js.rglSlider[0],js.rglSlider[1],
 			js.rgdwPOV[0],js.rgdwPOV[1],js.rgdwPOV[2],js.rgdwPOV[3],js.lVX,js.lVY,js.lVZ,js.lVRx,js.lVRy,js.lVRz,
 			js.rglVSlider[0],js.rglVSlider[1],js.lAX,js.lAY,js.lAZ,js.lARx,js.lARy,js.lARz,js.rglASlider[0],
-			js.rglASlider[1],js.lFX,js.lFY,js.lFZ,js.lFRx,js.lFRy,js.lFRz,js.rglFSlider[0],js.rglFSlider[0]};
+			js.rglASlider[1],js.lFX,js.lFY,js.lFZ,js.lFRx,js.lFRy,js.lFRz,js.rglFSlider[0],js.rglFSlider[1]};
 		// scale the numbers
 		for (int k=0;k<36;k++)
 			sample[k] /= 1000.0;


### PR DESCRIPTION
These are fixes I made to the GameController project while trying to get it to compile, link, and run. Hopefully you'll be willing to incorporate all/most of them. They should be generally useful to people building from the MS Windows solution/project.

1) Removed unneeded dependency on libowlsock.lib .
2) Added $(DXSDK_DIR)\lib\x86 library directory, for the DirectInput dependency.
3) Added post-build step to copy necessary DLLs to target directory.
4) Fixed the project inclusion of the generated moc_mainwindow.cpp so that the debug build doesn't depend on the release version having already been built.