### PR TITLE
Local IP address for multicasting

### DIFF
--- a/LSL/liblsl/src/api_config.cpp
+++ b/LSL/liblsl/src/api_config.cpp
@@ -99,6 +99,7 @@ void api_config::load_from_file(const std::string &filename) {
 
 		// read the [multicast] parameters
 		resolve_scope_ = pt.get("multicast.ResolveScope","site");
+		listen_address_ = pt.get("multicast.ListenAddress","");
 		std::vector<std::string> machine_group = parse_set(pt.get("multicast.MachineAddresses","{127.0.0.1, FF31:113D:6FDD:2C17:A643:FFE2:1BD1:3CD2}"));
 		std::vector<std::string> link_group = parse_set(pt.get("multicast.LinkAddresses","{255.255.255.255, 224.0.0.183, FF02:113D:6FDD:2C17:A643:FFE2:1BD1:3CD2}"));
 		std::vector<std::string> site_group = parse_set(pt.get("multicast.SiteAddresses","{239.255.172.215, FF05:113D:6FDD:2C17:A643:FFE2:1BD1:3CD2}"));

--- a/LSL/liblsl/src/api_config.h
+++ b/LSL/liblsl/src/api_config.h
@@ -93,6 +93,12 @@ namespace lsl {
 		*/
 		const std::vector<std::string> &multicast_addresses() const { return multicast_addresses_; }
 
+		/*
+		* The address of the local interface on which to listen to multicast traffic.
+		* The default is an empty string, i.e. bind to the default interface(s).
+		*/
+		const std::string &listen_address() const { return listen_address_; }
+
 		/**
 		* The TTL setting (time-to-live) for the multicast packets.
 		* This is determined according to the ResolveScope setting if not overridden by the TTLOverride setting.
@@ -185,6 +191,7 @@ namespace lsl {
 		std::string resolve_scope_;
 		std::vector<std::string> multicast_addresses_;
 		int multicast_ttl_;
+		std::string listen_address_;
 		std::vector<std::string> known_peers_;
 		std::string session_id_;
 		// tuning parameters

--- a/LSL/liblsl/src/stream_outlet_impl.cpp
+++ b/LSL/liblsl/src/stream_outlet_impl.cpp
@@ -61,6 +61,7 @@ stream_outlet_impl::stream_outlet_impl(const stream_info_impl &info, int chunk_s
 void stream_outlet_impl::instantiate_stack(tcp tcp_protocol, udp udp_protocol) {
 	// get api_config
 	const api_config *cfg = api_config::get_instance();
+	std::string listen_address = cfg->listen_address();
 	std::vector<std::string> multicast_addrs = cfg->multicast_addresses();
 	int multicast_ttl = cfg->multicast_ttl();
 	int multicast_port = cfg->multicast_port();
@@ -76,7 +77,7 @@ void stream_outlet_impl::instantiate_stack(tcp tcp_protocol, udp udp_protocol) {
 			// use only addresses for the protocol that we're supposed to use here
 			ip::address address(ip::address::from_string(*i));
 			if (udp_protocol == udp::v4() ? address.is_v4() : address.is_v6())
-				responders_.push_back(udp_server_p(new udp_server(info_, *ios_.back(), *i, multicast_port, multicast_ttl)));
+				responders_.push_back(udp_server_p(new udp_server(info_, *ios_.back(), *i, multicast_port, multicast_ttl, listen_address)));
 		} catch(std::exception &e) {
 			std::clog << "Note (minor): could not create multicast responder for address " << *i << " (failed with: " << e.what() << ")" << std::endl;
 		}

--- a/LSL/liblsl/src/udp_server.h
+++ b/LSL/liblsl/src/udp_server.h
@@ -39,7 +39,7 @@ namespace lsl {
 		* Create a new UDP server in multicast mode.
 		* This server will listen on a multicast address and responds only to LSL:shortinfo requests. This is for multicast/broadcast (and optionally unicast) local service discovery.
 		*/
-		udp_server(const stream_info_impl_p &info, boost::asio::io_service &io, const std::string &address, int port, int ttl);
+		udp_server(const stream_info_impl_p &info, boost::asio::io_service &io, const std::string &address, int port, int ttl, const std::string &listen_address);
 
 
 		/// Start serving UDP traffic.


### PR DESCRIPTION
Now multicasting can specify the local IP address to bind to. This is important if multicasting must be limited to one particular network, e.g. for a multihosted machine.

There's now a "multicast.ListenAddress" property in the lsl_api.cfg file; if missing, it defaults to an empty string, which preserves the previous behavior.