### PR TITLE
Fixed consumer_queue::pop_sample() to respect the timeout.

### DIFF
--- a/LSL/liblsl/src/consumer_queue.cpp
+++ b/LSL/liblsl/src/consumer_queue.cpp
@@ -1,5 +1,6 @@
 #include "consumer_queue.h"
 #include "send_buffer.h"
+#include "../include/lsl_c.h"
 #include <iostream>
 #include <boost/thread.hpp>
 
@@ -51,8 +52,12 @@ sample_p consumer_queue::pop_sample(double timeout) {
 	if (timeout <= 0.0) {
 		buffer_.pop(result);
 	} else {
-		while (!buffer_.pop(result))
+		timeout += lsl_local_clock();
+		while (!buffer_.pop(result)) {
+			if (lsl_local_clock() >= timeout)
+				throw timeout_error("The pop_sample() operation timed out.");
 			boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+		}
 	}
 	return result;
 }


### PR DESCRIPTION
It uses lsl_local_clock() to determine when the timeout has been exceeded, and throws a timeout_error exception.