### PR TITLE
Fixes to supergui.m and finputcheck.m to support newer Matlab figure handles

### DIFF
--- a/Apps/MATLABViewer/arg_system/private/finputcheck.m
+++ b/Apps/MATLABViewer/arg_system/private/finputcheck.m
@@ -215,6 +215,10 @@ function g = fieldtest( fieldname, fieldtype, fieldval, tmpval, callfunc );
           g = [ callfunc 'error: argument ''' fieldname ''' must be a structure' ]; return;
       end;
       
+     case 'handle'
+      if ~ishandle(tmpval)
+          g = [ callfunc 'error: argument ''' fieldname ''' must be a handle' ]; return;
+      end;
       
      case '';
      otherwise, error([ 'finputcheck error: unrecognized type ''' fieldname '''' ]);

--- a/Apps/MATLABViewer/arg_system/private/supergui.m
+++ b/Apps/MATLABViewer/arg_system/private/supergui.m
@@ -107,7 +107,7 @@ else
                 'geomvert' varargin{3} 'uilist'    varargin(4:end) }; 
 end
 g = finputcheck(options, { 'geomhoriz' 'cell'   []      {};
-                           'fig'       'real'   []      0;
+                           'fig'       'handle'   []      0;
                            'geom'      'cell'   []      {};
                            'uilist'    'cell'   []      {};
                            'title'     'string' []      '';


### PR DESCRIPTION
Modified supergui.m and finputcheck.m to use 'handle' instead of 'real' for figures. This now supports the use of Figure instances in newish Matlab ( >= 2014b ) and the old (>= 2006) use of floats to represent figure handles. This fixes #46 in upstream repo.