### PR TITLE
Add support for gcc 5

### DIFF
--- a/LSL/liblsl/external/CMakeLists.txt
+++ b/LSL/liblsl/external/CMakeLists.txt
@@ -58,3 +58,14 @@ else ()  # WIN32
   )
   set_property (TARGET boost PROPERTY COMPILE_DEFINITIONS BOOST_ALL_NO_LIB BOOST_THREAD_BUILD_LIB)
 endif (UNIX)
+
+# gcc 5 needs -std=c++0x to compile lslboost
+# CMAKE_CXX_COMPILER_VERSION is only available since CMake 2.8.8
+# If CMake version is inferior to 2.8.8, we assume gcc version is inferior to 5
+if (CMAKE_VERSION VERSION_GREATER 2.8.8)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+      set_property (TARGET boost PROPERTY COMPILE_FLAGS " -std=c++0x" APPEND_STRING)
+    endif ()
+  endif ()
+endif ()

--- a/LSL/liblsl/src/CMakeLists.txt
+++ b/LSL/liblsl/src/CMakeLists.txt
@@ -46,6 +46,15 @@ if (BUILD_SHARED)
   else ()
     target_link_libraries (lsl ${Boost_LIBRARIES})
   endif ()
+
+  if (CMAKE_VERSION VERSION_GREATER 2.8.8)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+	set_property (TARGET lsl PROPERTY COMPILE_FLAGS " -std=c++0x" APPEND_STRING)
+      endif ()
+    endif ()
+  endif()
+
 endif (BUILD_SHARED)
 
 if (BUILD_STATIC)
@@ -58,6 +67,15 @@ if (BUILD_STATIC)
     set_target_properties (lsl-static PROPERTIES OUTPUT_NAME lsl)
     target_link_libraries (lsl-static ${Boost_LIBRARIES} rt pthread)
   endif ()
+
+  if (CMAKE_VERSION VERSION_GREATER 2.8.8)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+	set_property (TARGET lsl-static PROPERTY COMPILE_FLAGS " -std=c++0x" APPEND_STRING)
+      endif ()
+    endif ()
+  endif()
+
 endif (BUILD_STATIC)
 
 


### PR DESCRIPTION
See issue #76 and pull request #101 
gcc 5 needs -std=c++0x to compile lslboost (based on boost 1.55).

Thus we check gcc version in CMakeLists.txt files.
As CMAKE_CXX_COMPILER_VERSION is only available since CMake 2.8.8,
if an older version of cmake is used, we assume gcc version is
inferior to 5.

