### PR TITLE
Compile liblsl on Windows with MinGW

### DIFF
--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -18,8 +18,18 @@
 * this header. Under Visual Studio the library is linked in automatically.
 */
 
-#ifdef _WIN32
-    #ifdef LIBLSL_EXPORTS
+#ifdef __MINGW32__
+    #ifdef LIBLSL_STATIC
+        #define LIBLSL_C_API
+    #elif defined (LIBLSL_EXPORTS)
+        #define LIBLSL_C_API __declspec(dllexport)
+    #else
+        #define LIBLSL_C_API __declspec(dllimport)
+    #endif
+#elif defined (_WIN32)
+    #ifdef LIBLSL_STATIC
+        #define LIBLSL_C_API
+    #elif defined (LIBLSL_EXPORTS)
         #define LIBLSL_C_API __declspec(dllexport)
     #else
         #ifndef _DEBUG

--- a/LSL/liblsl/src/CMakeLists.txt
+++ b/LSL/liblsl/src/CMakeLists.txt
@@ -33,11 +33,15 @@ message (${Boost_LIBRARIES})
 
 if (BUILD_SHARED)
   add_library (lsl SHARED ${sources})
-  
+
   # TODO: Need to check if all flags are necessary or if some flags are missing
   if (WIN32)
     set_property (TARGET lsl PROPERTY COMPILE_DEFINITIONS BOOST_ALL_NO_LIB BOOST_THREAD_BUILD_LIB LIBLSL_EXPORTS _SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_WARNINGS)
-    target_link_libraries (lsl ${Boost_LIBRARIES})
+    if (MINGW)
+      target_link_libraries (lsl ${Boost_LIBRARIES} winmm ws2_32 wsock32)
+    else ()
+      target_link_libraries (lsl ${Boost_LIBRARIES})
+    endif ()
   elseif (APPLE)
     target_link_libraries (lsl ${Boost_LIBRARIES} pthread)
   elseif (UNIX)
@@ -59,7 +63,8 @@ endif (BUILD_SHARED)
 
 if (BUILD_STATIC)
   add_library (lsl-static STATIC ${sources})
-  
+  set_property (TARGET lsl-static PROPERTY COMPILE_DEFINITIONS LIBLSL_STATIC)
+
   # TODO: Need to check if all flags are necessary or if some flags are missing
   # TODO: Add support for other platforms
   if (UNIX)


### PR DESCRIPTION
This patch allows to compile lsl library on Windows 7 with MinGW32 (with Qt Creator coming from "Qt 5.6.0 for Android (Windows 32-bit, 1.1GB)"), both for dynamic and
static versions. It also allows to compile the static version with Visual C++ (tested with
Visual Studio 2015).