### PR TITLE
force override default timestamps with lsl timestamps

### DIFF
--- a/LSL/liblsl/src/api_config.cpp
+++ b/LSL/liblsl/src/api_config.cpp
@@ -174,6 +174,7 @@ void api_config::load_from_file(const std::string &filename) {
 		inlet_buffer_reserve_ms_ = pt.get("tuning.InletBufferReserveMs",5000);
 		inlet_buffer_reserve_samples_ = pt.get("tuning.InletBufferReserveSamples",128);
 		smoothing_halftime_ = pt.get("tuning.SmoothingHalftime",90.0f);
+		force_default_timestamps_ = pt.get("tuning.ForceDefaultTimestamps", false);
 
 	} catch(std::exception &e) {
 		std::cerr << "Error parsing config file " << filename << " (" << e.what() << "). Rolling back to defaults." << std::endl;

--- a/LSL/liblsl/src/api_config.h
+++ b/LSL/liblsl/src/api_config.h
@@ -167,7 +167,8 @@ namespace lsl {
 		int inlet_buffer_reserve_samples() const { return inlet_buffer_reserve_samples_; }
 		/// Default halftime of the time-stamp smoothing window (if enabled), in seconds.
 		float smoothing_halftime() const { return smoothing_halftime_; }
-
+		/// Override timestamps with lsl clock if True
+		bool force_default_timestamps() const { return force_default_timestamps_; }
 
 	private:
 		// Thread-safe initialization logic (boilerplate).
@@ -220,6 +221,7 @@ namespace lsl {
 		int inlet_buffer_reserve_ms_;
 		int inlet_buffer_reserve_samples_;
 		float smoothing_halftime_;
+		bool force_default_timestamps_;
 	};
 }
 

--- a/LSL/liblsl/src/stream_outlet_impl.h
+++ b/LSL/liblsl/src/stream_outlet_impl.h
@@ -83,7 +83,9 @@ namespace lsl {
 		* @param pushthrough Whether to push the sample through to the receivers instead of buffering it into a chunk according to network speeds.
 		*/
 		void push_numeric_raw(void *data, double timestamp=0.0, bool pushthrough=true) { 
-			sample_p smp(sample_factory_->new_sample(timestamp==0.0 ? lsl_clock() : timestamp, pushthrough));
+			if (lsl::api_config::get_instance()->force_default_timestamps())
+				timestamp = 0.0;
+			sample_p smp(sample_factory_->new_sample(timestamp == 0.0 ? lsl_clock() : timestamp, pushthrough));
 			smp->assign_untyped(data);
 			send_buffer_->push_sample(smp);
 		}
@@ -172,7 +174,9 @@ namespace lsl {
 		* Allocate and enqueue a new sample into the send buffer.
 		*/
 		template<class T> void enqueue(T* data, double timestamp, bool pushthrough) { 
-			sample_p smp(sample_factory_->new_sample(timestamp==0.0 ? lsl_clock() : timestamp, pushthrough));
+			if (lsl::api_config::get_instance()->force_default_timestamps())
+				timestamp = 0.0;
+			sample_p smp(sample_factory_->new_sample(timestamp == 0.0 ? lsl_clock() : timestamp, pushthrough));
 			smp->assign_typed(data);
 			send_buffer_->push_sample(smp);
 		}


### PR DESCRIPTION
the ForceDefaultTimestamps parameter in the tuning section of the api config file now overrides the stream's default timestamps with LSL timestamps (lsl.local clock) if ForceDefaultTimestamps=true.