### PR TITLE
Prevent undefined shift

### DIFF
--- a/LSL/liblsl/src/portable_archive/portable_oarchive.hpp
+++ b/LSL/liblsl/src/portable_archive/portable_oarchive.hpp
@@ -333,8 +333,11 @@ namespace eos {
 				// examine the number of bytes
 				// needed to represent the number
 				signed char size = 0;
-				do { temp >>= CHAR_BIT; ++size; } 
-				while (temp != 0 && temp != (T) -1);
+				if(sizeof(T) == 1) size = 1;
+				else {
+					do { temp >>= CHAR_BIT; ++size; }
+					while (temp != 0 && temp != (T) -1);
+				}
 
 				// encode the sign bit into the size
 				save_signed_char(t > 0 ? size : -size);


### PR DESCRIPTION
Shifting single-byte types is undefined, so at least clang complains.
Since `t==0` is already handled, we know that they need one byte. This could also speed the function up a bit, as the compiler knows which branch to take at compile time.