### PR TITLE
plugged a memory leak

### DIFF
--- a/LSL/liblsl/src/sample.h
+++ b/LSL/liblsl/src/sample.h
@@ -87,12 +87,15 @@ namespace lsl {
 
 			/// Create a new sample with a given timestamp and pushthrough flag.
 			/// Only one thread may call this function for a given factory object.
+			
 			sample_p new_sample(double timestamp, bool pushthrough) { 
+				char *c = new char[sample_size_];
 				sample *result = pop_freelist();
 				if (!result)
-					result = new(new char[sample_size_]) sample(fmt_,num_chans_,this);
+					result = new(c) sample(fmt_,num_chans_,this);
 				result->timestamp = timestamp;
 				result->pushthrough = pushthrough;
+				free(c);
 				return sample_p(result);
 			}
 
@@ -159,9 +162,10 @@ namespace lsl {
 			if (format_ == cf_string)
 				for (std::string *p=(std::string*)&data_,*e=p+num_channels_; p<e; (p++)->~basic_string<char>());
 		}
-
+	
 		/// Delete a sample.
 		void operator delete(void *x) {
+			
 			// delete the underlying memory only if it wasn't allocated in the factory's storage area
 			sample *s = (sample*)x;
 			if (s && !(s->factory_ && (((char*)s) >= s->factory_->storage_.get() && ((char*)s) <= s->factory_->storage_.get()+s->factory_->storage_size_)))


### PR DESCRIPTION
So, I'm pretty sure I fixed the memory leak that I described in #191

This may not be the most elegant solution. Another option is making the inner argument to new (which used to be another constructor that created an object that never got freed as far as I can tell). Another solution would be to make a global smart pointer out of the object and let boost handle the memory management. 

I used a nifty (when it's not crashing visual studio) utility called Deleaker to find this little guy (http://www.deleaker.com/). I mention this mainly because there are 275 or so other leaks that he found, but my trial license expires in 6 days. I might be able to convince Brain Products to buy a license for me, but unless they do, I won't be able to fix all the others. This was the main one, though, and had a crippling effect on people that wanted to run at very high sampling rates (which is like one person in the whole world as far as I know). The other leaks don't seem to be repeating (i.e. on every call to pull_sample), so they aren't really a terrible problem. 