### PR TITLE
mem leak revised fix

### DIFF
--- a/LSL/liblsl/mem_leak_dummy/main.cpp
+++ b/LSL/liblsl/mem_leak_dummy/main.cpp
@@ -1,0 +1,100 @@
+
+#include <iostream>
+#include "main.h"
+
+
+
+void send_buffer::push_sample(sample_p samp) {
+	boost::lock_guard<boost::mutex> lock(mut);
+	for (queue_register::iterator i = queues_.begin(); i != queues_.end(); i++)
+		(*i)->push_sample(samp);
+}
+
+void send_buffer::register_queue(queue *q) {
+	boost::lock_guard<boost::mutex> lock(mut);
+	queues_.insert(q);
+}
+
+queue_p send_buffer::new_queue(int size) {
+	return queue_p(new queue(100, shared_from_this()));
+}
+
+// queue definitions
+queue::queue(int size, const send_buffer_p &send_buffer) : buffer_(size), send_buffer_(send_buffer) {
+	send_buffer_->register_queue(this);
+}
+
+void queue::push_sample(const sample_p &samp) {
+
+	while (!buffer_.push(samp)) {
+		sample_p dummy;
+		buffer_.pop(dummy);
+	}
+}
+
+sample_p queue::pop_sample(void) {
+	sample_p result;
+	do {
+		boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+	} while (!buffer_.pop(result));
+	return result;
+}
+
+// server defenitions
+server::server(const send_buffer_p &send_buffer) : send_buffer_(send_buffer), factory_(new sample::factory()){
+	
+
+}
+
+
+void server::write_samples() {
+
+	for (int i = 0; i < 100; i++)
+	{
+		sample_p s = factory_->new_sample(100, (double) i);
+		send_buffer_->push_sample(s);
+	}
+
+}
+
+// client definitions
+client::client(const server_p &serv) : serv_(serv){}
+
+bool keep_clienting;
+void client::read_samples(void) {
+
+	queue_p q = serv_->send_buffer_->new_queue(100);
+	while(keep_clienting) {
+		sample_p samp = q->pop_sample();
+		std::cout << samp->data << std::endl;
+	}
+
+}
+
+int main(void) {
+	keep_clienting = true;
+
+	send_buffer_p the_send_buffer(new send_buffer());
+	queue_p the_queue(new queue(100, the_send_buffer));
+	server_p the_server(new server(the_send_buffer));
+	client the_client(the_server);
+
+	boost::thread t1(boost::bind(&client::read_samples, &the_client));
+	std::cout << "enter a to send 100 samples, b to exit" << std::endl;
+	char foo = 'x';
+	while (foo != 'b') {
+		std::cin >> foo;
+		if (foo == 'a')
+			the_server->write_samples();
+		if (foo == 'b') {
+			keep_clienting = false;
+			// send one last sample to continue through the receive loop
+			the_server->send_buffer_->push_sample(the_server->factory_->new_sample(1, 0.0));
+			break;
+		}
+	}
+		
+	t1.join();
+
+	return 0;
+}

--- a/LSL/liblsl/mem_leak_dummy/main.h
+++ b/LSL/liblsl/mem_leak_dummy/main.h
@@ -1,0 +1,90 @@
+#pragma once
+#include <set>
+#include <boost/container/flat_set.hpp>
+#include <boost/intrusive_ptr.hpp>
+#include <boost/lockfree/spsc_queue.hpp>
+#include <boost/atomic.hpp>
+#include <boost/thread.hpp>
+#include <boost/enable_shared_from_this.hpp>
+
+typedef boost::intrusive_ptr<class sample> sample_p;
+typedef boost::lockfree::spsc_queue<sample_p> buffer;
+typedef boost::shared_ptr<class queue> queue_p;
+typedef boost::container::flat_set<queue*> queue_register;
+typedef boost::shared_ptr<class server> server_p;
+typedef boost::shared_ptr<class send_buffer> send_buffer_p;
+
+
+class sample {
+
+public:
+	double data;
+	class factory;
+	typedef boost::shared_ptr<class factory> factory_p;
+	class factory {
+	public:
+		friend class sample;
+		sample_p new_sample(int size, double data) {
+			sample* result = new(new char[size]) sample(data);
+			return sample_p(result);
+		}
+	};
+
+	sample(double d) : ref_count(0){
+		data = d;
+		
+	}
+
+	void operator delete(void *x) {
+		delete[](char*)x;
+	}
+
+	boost::atomic<int> ref_count;
+	/// Increment ref count.
+	friend void intrusive_ptr_add_ref(sample *s) {
+		s->ref_count.fetch_add(1, boost::memory_order_relaxed);
+	}
+
+	/// Decrement ref count and reclaim if unreferenced.
+	friend void intrusive_ptr_release(sample *s) {
+		if (s->ref_count.fetch_sub(1, boost::memory_order_release) == 1)
+			// do nothing and leak memory
+			;
+			// free memory and cause problems
+			//delete[](char*)s;
+	}
+
+};
+
+class send_buffer : public boost::enable_shared_from_this<send_buffer>{
+public:
+	queue_register queues_;
+	boost::mutex mut;
+	void push_sample(sample_p samp);
+	void register_queue(queue *q);
+	queue_p send_buffer::new_queue(int size);
+};
+
+class queue {
+public:
+	buffer buffer_;
+	send_buffer_p send_buffer_;
+	queue(int size, const send_buffer_p &send_buffer);
+	void push_sample(const sample_p &samp);
+	sample_p pop_sample(void);
+};
+
+class server : public boost::enable_shared_from_this<server> {
+public:
+	send_buffer_p send_buffer_;
+	sample::factory_p factory_;
+	server(const send_buffer_p &send_buffer);
+	void write_samples();
+};
+
+class client : public boost::enable_shared_from_this<client>{
+public:
+	server_p serv_;
+	client(const server_p &serv);
+	void read_samples(void);
+};

--- a/LSL/liblsl/mem_leak_dummy/mem_leak_dummy.sln
+++ b/LSL/liblsl/mem_leak_dummy/mem_leak_dummy.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mem_leak_dummy", "mem_leak_dummy.vcxproj", "{85BCCCC1-B226-4A86-9623-C41394BF7F71}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{85BCCCC1-B226-4A86-9623-C41394BF7F71}.Debug|Win32.ActiveCfg = Debug|Win32
+		{85BCCCC1-B226-4A86-9623-C41394BF7F71}.Debug|Win32.Build.0 = Debug|Win32
+		{85BCCCC1-B226-4A86-9623-C41394BF7F71}.Release|Win32.ActiveCfg = Release|Win32
+		{85BCCCC1-B226-4A86-9623-C41394BF7F71}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/LSL/liblsl/mem_leak_dummy/mem_leak_dummy.vcxproj
+++ b/LSL/liblsl/mem_leak_dummy/mem_leak_dummy.vcxproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{85BCCCC1-B226-4A86-9623-C41394BF7F71}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>mem_leak_dummy</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_SCL_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(BOOST_ROOT)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(BOOST_ROOT)\lib</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/LSL/liblsl/src/sample.h
+++ b/LSL/liblsl/src/sample.h
@@ -88,9 +88,13 @@ namespace lsl {
 			/// Create a new sample with a given timestamp and pushthrough flag.
 			/// Only one thread may call this function for a given factory object.
 			sample_p new_sample(double timestamp, bool pushthrough) { 
+				char * c = NULL;
 				sample *result = pop_freelist();
-				if (!result)
-					result = new(new char[sample_size_]) sample(fmt_,num_chans_,this);
+				if (!result){
+					c = new char[sample_size_];
+					result = new(c) sample(fmt_,num_chans_,this);
+					delete c;
+				}
 				result->timestamp = timestamp;
 				result->pushthrough = pushthrough;
 				return sample_p(result);

--- a/LSL/liblsl/src/tcp_server.cpp
+++ b/LSL/liblsl/src/tcp_server.cpp
@@ -369,6 +369,7 @@ void tcp_server::client_session::handle_send_feedheader_outcome(error_code err, 
 
 /// Transfers samples from the server's send buffer into the async send queues of the IO threads.
 void tcp_server::client_session::transfer_samples_thread(client_session_p) {
+	
 	if (max_buffered_ <= 0)
 		return;
 	try {
@@ -404,8 +405,12 @@ void tcp_server::client_session::transfer_samples_thread(client_session_p) {
 					completion_cond_.wait(lock, boost::bind(&client_session::transfer_completed,this));
 					//at this point we should be done with the sample
 					if (!samp->is_managed)
+						// update the number of unmanaged samples to free
+						completion_mut_.lock();
+						serv_->factory_->garbage_cnt++;
+						completion_mut_.unlock();
 						// only delete unmanaged samples
-						delete samp.get();
+						//delete samp.get();
 					// handle transfer outcome
 					if (!transfer_error_) {
 						feedbuf_.consume(transfer_amount_);

--- a/LSL/liblsl/src/tcp_server.cpp
+++ b/LSL/liblsl/src/tcp_server.cpp
@@ -402,6 +402,10 @@ void tcp_server::client_session::transfer_samples_thread(client_session_p) {
 						boost::bind(&client_session::handle_chunk_transfer_outcome,shared_from_this(),placeholders::error,placeholders::bytes_transferred));
 					// wait for the completion condition
 					completion_cond_.wait(lock, boost::bind(&client_session::transfer_completed,this));
+					//at this point we should be done with the sample
+					if (!samp->is_managed)
+						// only delete unmanaged samples
+						delete samp.get();
 					// handle transfer outcome
 					if (!transfer_error_) {
 						feedbuf_.consume(transfer_amount_);

--- a/LSL/liblsl/src/tcp_server.cpp
+++ b/LSL/liblsl/src/tcp_server.cpp
@@ -405,12 +405,7 @@ void tcp_server::client_session::transfer_samples_thread(client_session_p) {
 					completion_cond_.wait(lock, boost::bind(&client_session::transfer_completed,this));
 					//at this point we should be done with the sample
 					if (!samp->is_managed)
-						// update the number of unmanaged samples to free
-						completion_mut_.lock();
-						serv_->factory_->garbage_cnt++;
-						completion_mut_.unlock();
-						// only delete unmanaged samples
-						//delete samp.get();
+						malloc(samp.get());
 					// handle transfer outcome
 					if (!transfer_error_) {
 						feedbuf_.consume(transfer_amount_);


### PR DESCRIPTION
Replaces #234 

>Ok. I think I got it now. This seems not to crash anything, but more testing is required. I tested it sending 8 floats at a time at 100 Hz. I don't see any reason that this wouldn't scale up to any sampling rate or any data size (within the limits of LSL) but who knows. I would like to test it at high sampling rates, with large data sizes, and with markers.

>So, no. The memory profiler did show me a leak, and the above is a plug, but the underlying problem of high sampling rates is still unresolved. I think this has something to do with boost::asio. Either there is a bug in boost::asio itself that nobody till now has noticed (unlikely), or else a buffer is growing somewhere where I can't see it.

>The heap memory management in LSL is fairly complicated and pointers get allocated and free in many different ways. I am going to leave the PR up for now but this is far from over.

>Ok. More updates. I am pretty much stuck. There are actually two leaks. The first is detectable with deleaker and perceptible through the usual Visual Studio diagnostic tools. This is the one I plugged here: https://github.com/sccn/labstreaminglayer/commit/38e4ced06c463f520196940ab1772ba2f7c56d33

>However, with this patch, an outlet can only connect to one inlet. So it seems that this inner allocation of memory is not being freed. I tried using a shared_ptr here, but that doesn't work at all.

>The other issue is that in addition to this, there is a slow leak that I cannot locate. I've been through the whole pipeline until samples go behind the shadow of boost::asio in the tcp service, and as far as I can tell, everything is rock solid. Boost is never wrong, so I doubt there is a problem there. Just in case, I pinged the boost list. I also tried adding some boost::asio::io_service::work objects as per this suggestion: https://stackoverflow.com/questions/32258890/c-boost-asio-async-send-to-memory-leak but it seems to have no effect.
