### PR TITLE
Add lsl_library_info() function to return more useful version information

### DIFF
--- a/Apps/OutOfTreeTest/OutOfTreeTest.c
+++ b/Apps/OutOfTreeTest/OutOfTreeTest.c
@@ -6,5 +6,5 @@
  */
 
 int main(int argc, char* argv[]) {
-	printf("Using LSL version %d\n", lsl_library_version());
+	printf("Using LSL version %d (%s)\n", lsl_library_version(), lsl_library_info());
 }

--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -200,6 +200,11 @@ extern LIBLSL_C_API int lsl_protocol_version();
 */
 extern LIBLSL_C_API int lsl_library_version();
 
+/**
+* Get a string containing library information. The format of the string shouldn't be used
+* for anything important except giving a a debugging person a good idea which exact library
+* version is used. */
+extern LIBLSL_C_API const char* lsl_library_info();
 
 /**
 * Obtain a local system time stamp in seconds. The resolution is better than a millisecond.

--- a/LSL/liblsl/include/lsl_cpp.h
+++ b/LSL/liblsl/include/lsl_cpp.h
@@ -97,6 +97,12 @@ namespace lsl {
     */
     inline int library_version() { return lsl_library_version(); }
 
+	/**
+	* Get a string containing library information. The format of the string shouldn't be used
+	* for anything important except giving a a debugging person a good idea which exact library
+	* version is used. */
+	inline const char* lsl_library_info() { return lsl_library_info(); }
+
     /**
     * Obtain a local system time stamp in seconds. The resolution is better than a millisecond.
     * This reading can be used to assign time stamps to samples as they are being acquired. 

--- a/LSL/liblsl/src/lsl_freefuncs_c.cpp
+++ b/LSL/liblsl/src/lsl_freefuncs_c.cpp
@@ -21,6 +21,15 @@ LIBLSL_C_API int lsl_protocol_version() { return api_config::get_instance()->use
 */
 LIBLSL_C_API int lsl_library_version() { return LSL_LIBRARY_VERSION; }
 
+/** Get a string containing library information */
+LIBLSL_C_API const char* lsl_library_info() {
+#ifdef LSL_LIBRARY_INFO_STR
+	return LSL_LIBRARY_INFO_STR;
+#else
+	return "Unknown (not set by build system)";
+#endif
+}
+
 /**
 * Obtain a local system time stamp in seconds. The resolution is better than a millisecond.
 * This reading can be used to assign time stamps to samples as they are being acquired. 


### PR DESCRIPTION
`lsl_library_info` returns a string hopefully helpful in debugging, especially when the source of the shared library isn't known.
An other use case is in comparing benchmarks to compare commits.

An example of this string is `git:v1.12-216-g147f2cc0/build:Release/compiler:Clang-5.0.0/boost:1_65_1`

Currently, the following fields are reported:
- `git`: last git tag (e.g. `v1.12`) + commits since that tag (`216`) + shortened commit hash (`g147...`)
- `build`: Debug or Release
- `compiler`: name and version
- boost: whatever `BOOST_LIB_VERSION` reports