### PR TITLE
Apps cmake revision win

### DIFF
--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -58,29 +58,21 @@ add_executable(${target}
     targetver.h
 )
 
-
-find_package(Boost REQUIRED COMPONENTS system chrono date_time filesystem iostreams thread zlib)
-include_directories(${Boost_INCLUDE_DIRS})
-#link_libraries(${Boost_LIBRARIES})
-
-#IF(MSVC)
-#    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread zlib)
-#    set(zlib_libs Boost::zlib)
-#ELSE()
-#    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread)
-#    find_package(ZLIB REQUIRED)
-#    set(zlib_libs ${ZLIB_LIBRARIES})
-#ENDIF()
+IF(MSVC)
+    find_package(Boost REQUIRED system chrono date_time filesystem iostreams thread zlib)
+	set(req_libs ${Boost_LIBRARIES})
+	INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${BOOST_ROOT})
+ELSE()
+    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread)
+    find_package(ZLIB REQUIRED)
+	set(req_libs Boost::filesystem Boost::iostreams Boost::thread ${ZLIB_LIBRARIES})
+ENDIF()
 #INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${BOOST_ROOT})
 target_link_libraries(${target}
     PRIVATE
     Qt5::Widgets
     Qt5::Network
-	${Boost_LIBRARIES}
-    #Boost::filesystem
-    #Boost::iostreams
-    #Boost::thread
-    #${zlib_libs}
+	${req_libs}
     LSL::lsl
 )
 

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -58,22 +58,10 @@ add_executable(${target}
     targetver.h
 )
 
-set(Boost_NO_SYSTEM_PATHS true)
-set (Boost_USE_STATIC_LIBS OFF CACHE BOOL "use static libraries from Boost")
-set (Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_LIBS ON)
+
 find_package(Boost REQUIRED COMPONENTS system chrono date_time filesystem iostreams thread zlib)
 include_directories(${Boost_INCLUDE_DIRS})
 #link_libraries(${Boost_LIBRARIES})
-
-if (WIN32)
-  # disable autolinking in boost
-  add_definitions( -DBOOST_ALL_NO_LIB )
-
-  # force all boost libraries to dynamic link (we already disabled
-  # autolinking, so I don't know why we need this, but we do!)
-  #add_definitions( -DBOOST_ALL_DYN_LINK )
-endif()
 
 #IF(MSVC)
 #    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread zlib)

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -58,23 +58,41 @@ add_executable(${target}
     targetver.h
 )
 
-IF(MSVC)
-    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread zlib)
-    set(zlib_libs Boost::zlib)
-ELSE()
-    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread)
-    find_package(ZLIB REQUIRED)
-    set(zlib_libs ${ZLIB_LIBRARIES})
-ENDIF()
+set(Boost_NO_SYSTEM_PATHS true)
+set (Boost_USE_STATIC_LIBS OFF CACHE BOOL "use static libraries from Boost")
+set (Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED COMPONENTS system chrono date_time filesystem iostreams thread zlib)
+include_directories(${Boost_INCLUDE_DIRS})
+#link_libraries(${Boost_LIBRARIES})
 
+if (WIN32)
+  # disable autolinking in boost
+  add_definitions( -DBOOST_ALL_NO_LIB )
+
+  # force all boost libraries to dynamic link (we already disabled
+  # autolinking, so I don't know why we need this, but we do!)
+  #add_definitions( -DBOOST_ALL_DYN_LINK )
+endif()
+
+#IF(MSVC)
+#    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread zlib)
+#    set(zlib_libs Boost::zlib)
+#ELSE()
+#    find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread)
+#    find_package(ZLIB REQUIRED)
+#    set(zlib_libs ${ZLIB_LIBRARIES})
+#ENDIF()
+#INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${BOOST_ROOT})
 target_link_libraries(${target}
     PRIVATE
     Qt5::Widgets
     Qt5::Network
-    Boost::filesystem
-    Boost::iostreams
-    Boost::thread
-    ${zlib_libs}
+	${Boost_LIBRARIES}
+    #Boost::filesystem
+    #Boost::iostreams
+    #Boost::thread
+    #${zlib_libs}
     LSL::lsl
 )
 

--- a/cmake/LSLAppBoilerplate.cmake
+++ b/cmake/LSLAppBoilerplate.cmake
@@ -39,15 +39,11 @@ set(CMAKE_AUTORC ON)
 # Boost
 #SET(Boost_DEBUG OFF) #Switch this and next to ON for help debugging Boost problems.
 #SET(Boost_DETAILED_FAILURE_MSG ON)
-#if(WIN32)
-	#set(Boost_USE_STATIC_LIBS ON)
-#endif()
+if(WIN32)
+	set(Boost_USE_STATIC_LIBS ON)
+endif()
 
 IF(MSVC)
-	set(Boost_NO_SYSTEM_PATHS true)
-	set (Boost_USE_STATIC_LIBS OFF CACHE BOOL "use static libraries from Boost")
-	set (Boost_USE_MULTITHREADED ON)
-	set(Boost_USE_STATIC_LIBS ON)
 	# Disable boost auto linking.
 	add_definitions(-DBOOST_ALL_NO_LIB )
 endif()

--- a/cmake/LSLAppBoilerplate.cmake
+++ b/cmake/LSLAppBoilerplate.cmake
@@ -40,12 +40,12 @@ set(CMAKE_AUTORC ON)
 #SET(Boost_DEBUG OFF) #Switch this and next to ON for help debugging Boost problems.
 #SET(Boost_DETAILED_FAILURE_MSG ON)
 if(WIN32)
-	set(Boost_USE_STATIC_LIBS ON)
+	#set(Boost_USE_STATIC_LIBS ON)
 endif()
 
 IF(MSVC)
 	# Disable boost auto linking.
-	add_definitions(-DBOOST_ALL_NO_LIB )
+	#add_definitions(-DBOOST_ALL_NO_LIB )
 endif()
 
 

--- a/cmake/LSLAppBoilerplate.cmake
+++ b/cmake/LSLAppBoilerplate.cmake
@@ -39,13 +39,17 @@ set(CMAKE_AUTORC ON)
 # Boost
 #SET(Boost_DEBUG OFF) #Switch this and next to ON for help debugging Boost problems.
 #SET(Boost_DETAILED_FAILURE_MSG ON)
-if(WIN32)
+#if(WIN32)
 	#set(Boost_USE_STATIC_LIBS ON)
-endif()
+#endif()
 
 IF(MSVC)
+	set(Boost_NO_SYSTEM_PATHS true)
+	set (Boost_USE_STATIC_LIBS OFF CACHE BOOL "use static libraries from Boost")
+	set (Boost_USE_MULTITHREADED ON)
+	set(Boost_USE_STATIC_LIBS ON)
 	# Disable boost auto linking.
-	#add_definitions(-DBOOST_ALL_NO_LIB )
+	add_definitions(-DBOOST_ALL_NO_LIB )
 endif()
 
 


### PR DESCRIPTION
This is my solution to the problems I was having building LabRecorder in and out of tree as lengthily detailed here: https://github.com/sccn/labstreaminglayer/issues/241.

This needs cleaning up, but if you could give me your comments, I would be grateful. I don't have anything pointing to boost or qt in my path. This might be why this was not working on my machine. I don't see how this would even build otherwise. There were a number of required libraries left ot of the call to find_package(bosst etc.)

This is the line I used to make the projects:
`cmake ../ -DCMAKE_PREFIX_PATH=C:\Qt-VS2015_x64\Qt5.7.1\5.7\msvc2015_64 -DQt5_DIR=C:\Qt-VS2015_x64\Qt5.7.1\5.7\msvc2015_64 -DBOOST_ROOT=C:\local\boost_1_65_1 -DBOOST_LIBRARYDIR=C:\local\boost_1_65_1\lib64-msvc-14.0 -DBOOST_INCLUDEDIR=C:\local\boost_1_65_1\boost -DLSL_INSTALL_ROOT=C:\Users\David.Medine\clean_lsl\labstreaminglayer\build\install\lsl_Release\LSL -DLSLAPPS_LabRecorder=ON -G "Visual Studio 14 2015 Win64" `

I futzed with the standard Qt paths some, but the boost package was right out of the box. Also, all these includes are necessary or it doesn't work.