### PR TITLE
Simplify symbol export

### DIFF
--- a/LSL/liblsl/CMakeLists.txt
+++ b/LSL/liblsl/CMakeLists.txt
@@ -97,14 +97,13 @@ add_subdirectory(${LSL_LSLBOOST_PATH})
 function(lsllib_properties libname)
 	target_link_libraries(${libname} PRIVATE lslboost)
 	target_include_directories(${libname}
-		PRIVATE
-		${CMAKE_CURRENT_BINARY_DIR} # generated export header
 		INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 	)
 	target_compile_definitions(${libname} PRIVATE
-		LSL_INCLUDE_EXPORT_DEFINES
 		LIBLSL_EXPORTS
 		_SCL_SECURE_NO_WARNINGS _CRT_SECURE_NO_WARNINGS
+		PUBLIC
+		LSLNOAUTOLINK # don't use #pragma(lib) in CMake builds
 	)
 endfunction()
 
@@ -124,19 +123,10 @@ if(${LSL_BUILD_STATIC})
 	lsllib_properties(${target}-static)
 	list(APPEND lsl_export_targets "${target}-static")
 	# for LSL_CPP_API export header
-	target_compile_definitions(${target}-static PRIVATE LSL_STATIC_DEFINE)
+	target_compile_definitions(${target}-static PRIVATE LIBLSL_STATIC)
 	set_target_properties(${target}-static PROPERTIES
 		OUTPUT_NAME "${target}${lslplatform}-static")
 endif()
-
-# Generate with LIBLSL_CPP_API exports
-include(GenerateExportHeader)
-generate_export_header(${target}
-	BASE_NAME LSL
-	EXPORT_MACRO_NAME LIBLSL_CPP_API
-	EXPORT_FILE_NAME lsl_export_defines.h
-	STATIC_DEFINE LIBLSL_STATIC
-)
 
 if (MINGW)
 	target_link_libraries (${target} PUBLIC ws2_32 wsock32 winmm)

--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -17,48 +17,30 @@
 * To use this library you need to link to either the liblsl32 or liblsl64 shared library that comes with
 * this header. Under Visual Studio the library is linked in automatically.
 */
-
-#ifdef __MINGW32__
-    #ifdef LIBLSL_STATIC
-        #define LIBLSL_C_API
-    #elif defined (LIBLSL_EXPORTS)
+#ifdef LIBLSL_STATIC
+    #define LIBLSL_C_API
+#elif defined _WIN32 || defined __CYGWIN__
+    #if defined LIBLSL_EXPORTS
         #define LIBLSL_C_API __declspec(dllexport)
     #else
         #define LIBLSL_C_API __declspec(dllimport)
-    #endif
-#elif defined (_WIN32)
-    #ifdef LIBLSL_STATIC
-        #define LIBLSL_C_API
-    #elif defined (LIBLSL_EXPORTS)
-        #define LIBLSL_C_API __declspec(dllexport)
-    #else
-        #ifndef _DEBUG
-            #ifdef _WIN64
-                #pragma comment (lib,"liblsl64.lib")
-            #else
-                #pragma comment (lib,"liblsl32.lib")
-            #endif
+        #ifdef _WIN64
+            #define LSLBITS "64"
         #else
-            #ifdef LSL_DEBUG_BINDINGS
-                #ifdef _WIN64
-                    #pragma comment (lib,"liblsl64-debug.lib")
-                #else
-                    #pragma comment (lib,"liblsl32-debug.lib")
-                #endif
-            #else
-                #ifdef _WIN64
-                    #pragma comment (lib,"liblsl64.lib")
-                #else
-                    #pragma comment (lib,"liblsl32.lib")
-                #endif
-            #endif
+            #define LSLBITS "32"
         #endif
-        #define LIBLSL_C_API __declspec(dllimport)
+        #if defined _DEBUG && defined LSL_DEBUG_BINDINGS
+            #define LSLLIBPOSTFIX "-debug"
+        #else
+            #define LSLLIBPOSTFIX ""
+        #endif
+        #ifndef LSLNOAUTOLINK
+            #pragma comment (lib, "liblsl" LSLBITS LSLLIBPOSTFIX ".lib")
+        #endif
     #endif
     #pragma warning (disable:4275)
-#else
-    #pragma GCC visibility push(default)
-    #define LIBLSL_C_API
+#else // Linux / OS X
+    #define LIBLSL_C_API __attribute__((visibility("default")))
 #endif
 
 
@@ -1009,10 +991,6 @@ extern LIBLSL_C_API void lsl_destroy_continuous_resolver(lsl_continuous_resolver
 } /* end extern "C" */
 #endif
 
-
-#ifndef _WIN32
-    #pragma GCC visibility pop
-#endif
 
 #endif
 

--- a/LSL/liblsl/src/common.h
+++ b/LSL/liblsl/src/common.h
@@ -4,23 +4,15 @@
 #include <stdexcept>
 #include <boost/version.hpp>
 
-#ifdef LSL_INCLUDE_EXPORT_DEFINES
-// export defines header automatically created by CMake
-#include "lsl_export_defines.h"
-#else
-//Apply settings for the most common compilers
 #ifdef _WIN32
 #define LIBLSL_CPP_API __declspec(dllexport)
 #else
 #define LIBLSL_CPP_API
-#pragma GCC visibility push(default)
-#endif
 #endif
 
 #ifdef _MSC_VER
 #pragma warning( disable : 4275 )
 #endif
-
 
 #if BOOST_VERSION < 104500
 	#error "Please do not compile this with a lslboost version older than 1.45 because the library would otherwise not be protocol-compatible with builds using other versions."

--- a/OutOfTreeTest/CMakeLists.txt
+++ b/OutOfTreeTest/CMakeLists.txt
@@ -16,9 +16,12 @@ include(LSLAppBoilerplate)
 
 add_executable(LSLOutOfTreeTest OutOfTreeTest.c)
 target_link_libraries(LSLOutOfTreeTest PRIVATE LSL::lsl)
+add_executable(LSLOutOfTreeTest-static OutOfTreeTest.c)
+target_link_libraries(LSLOutOfTreeTest-static PRIVATE LSL::lsl-static)
 add_custom_target(runOutOfTree
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:LSL::lsl> $<TARGET_FILE_DIR:LSLOutOfTreeTest>
 	COMMAND LSLOutOfTreeTest
+	COMMAND LSLOutOfTreeTest-static
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMENT "run generated test executable"
 )


### PR DESCRIPTION
This PR doesn't change anything for the non-CMake, VC-builds.
For CMake builds, `LSLNOAUTOLINK` is set to disable the Windows+VC-only linking (because CMake already takes care of it).

When `LIBLSL_STATIC` is set, no visibility flags are set, otherwise all symbols marked with `LIBLSL_C_API` are marked as imported from a shared library or marked as export when `LIBLSL_EXPORTS` is set.