### PR TITLE
Move error code handling from C functions to C++ implementation

### DIFF
--- a/LSL/liblsl/src/common.h
+++ b/LSL/liblsl/src/common.h
@@ -77,6 +77,19 @@ namespace lsl {
 		post_ALL = 1|2|4|8		// The combination of all possible post-processing options.
 	};
 
+#ifndef LSL_C_H
+	/**
+	* Possible error codes.
+	*/
+	typedef enum {
+	    lsl_no_error = 0,           /* No error occurred */
+	    lsl_timeout_error = -1,     /* The operation failed due to a timeout. */
+	    lsl_lost_error = -2,        /* The stream has been lost. */
+	    lsl_argument_error = -3,    /* An argument was incorrectly specified (e.g., wrong format or wrong length). */
+	    lsl_internal_error = -4     /* Some other internal error has happened. */
+	} lsl_error_code_t;
+#endif
+
 	/// Exception class that indicates that a stream inlet's source has been irrecoverably lost.
 	class LIBLSL_CPP_API lost_error: public std::runtime_error {
 	public:

--- a/LSL/liblsl/src/lsl_inlet_c.cpp
+++ b/LSL/liblsl/src/lsl_inlet_c.cpp
@@ -201,177 +201,27 @@ LIBLSL_C_API int lsl_set_postprocessing(lsl_inlet in, unsigned flags) {
 * @param ec Error code: if nonzero, can be either lsl_timeout_error (if the timeout has expired) or lsl_lost_error (if the stream source has been lost).
 */
 LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, short *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, int buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_sample(buffer,buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0.0;
+		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
 LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int buffer_elements, double timeout, int *ec) {
@@ -505,177 +355,27 @@ LIBLSL_C_API double lsl_pull_sample_v(lsl_inlet in, void *buffer, int buffer_byt
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, short *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
-	if (ec)
-		*ec = lsl_no_error;
-	try {
-		return ((stream_inlet_impl*)in)->pull_chunk_multiplexed(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
-	}
-	catch(timeout_error &) { 
-		if (ec)
-			*ec = lsl_timeout_error; 
-	}
-	catch(lost_error &) { 
-		if (ec)
-			*ec = lsl_lost_error; 
-	}
-	catch(std::invalid_argument &) { 
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::range_error &) {
-		if (ec)
-			*ec = lsl_argument_error; 
-	}
-	catch(std::exception &) { 
-		if (ec)
-			*ec = lsl_internal_error; 
-	}
-	return 0;
+	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
 LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {

--- a/LSL/liblsl/src/lsl_outlet_c.cpp
+++ b/LSL/liblsl/src/lsl_outlet_c.cpp
@@ -28,345 +28,75 @@ LIBLSL_C_API void lsl_destroy_outlet(lsl_outlet out) {
 }
 
 LIBLSL_C_API int lsl_push_sample_f(lsl_outlet out, float *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data);
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_ft(lsl_outlet out, float *data, double timestamp) {
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_ftp(lsl_outlet out, float *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_d(lsl_outlet out, double *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_dt(lsl_outlet out, double *data, double timestamp) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_dtp(lsl_outlet out, double *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_l(lsl_outlet out, long *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_lt(lsl_outlet out, long *data, double timestamp) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_ltp(lsl_outlet out, long *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_i(lsl_outlet out, int *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_it(lsl_outlet out, int *data, double timestamp) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_itp(lsl_outlet out, int *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_s(lsl_outlet out, short *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_st(lsl_outlet out, short *data, double timestamp) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_stp(lsl_outlet out, short *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_c(lsl_outlet out, char *data) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data);
 }
 
 LIBLSL_C_API int lsl_push_sample_ct(lsl_outlet out, char *data, double timestamp) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp);
 }
 
 LIBLSL_C_API int lsl_push_sample_ctp(lsl_outlet out, char *data, double timestamp, int pushthrough) { 
-	try {
-		((stream_outlet_impl*)out)->push_sample(data,timestamp,pushthrough!=0); 
-		return lsl_no_error;
-	} 
-	catch(std::range_error &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::invalid_argument &e) {
-		std::cerr << "Error during push_sample: " << e.what() << std::endl;
-		return lsl_argument_error;
-	}
-	catch(std::exception &e) {
-		std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
-		return lsl_internal_error;
-	}
+	return ((stream_outlet_impl*)out)->push_sample_noexcept(data, timestamp, pushthrough);
 }
 
 LIBLSL_C_API int lsl_push_sample_v(lsl_outlet out, void *data) { 

--- a/LSL/liblsl/src/stream_outlet_impl.h
+++ b/LSL/liblsl/src/stream_outlet_impl.h
@@ -76,6 +76,25 @@ namespace lsl {
 		void push_sample(const char *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 		void push_sample(const std::string *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 
+
+	    template <typename T>
+	    inline lsl_error_code_t push_sample_noexcept(const T* data, double timestamp = 0.0,
+		                                             bool pushthrough = true) BOOST_NOEXCEPT {
+		    try {
+			    enqueue(data, timestamp, pushthrough);
+			    return lsl_no_error;
+		    } catch (std::range_error& e) {
+			    std::cerr << "Error during push_sample: " << e.what() << std::endl;
+			    return lsl_argument_error;
+		    } catch (std::invalid_argument& e) {
+			    std::cerr << "Error during push_sample: " << e.what() << std::endl;
+			    return lsl_argument_error;
+		    } catch (std::exception& e) {
+			    std::cerr << "Unexpected error during push_sample: " << e.what() << std::endl;
+			    return lsl_internal_error;
+		    }
+	    }
+
 		/**
 		* Push a pointer to raw numeric data as one sample into the outlet. 
 		* This is the lowest-level function; does no checking of any kind. Do not use for variable-size/string data-formatted channels.


### PR DESCRIPTION
Most C API functions try to call a C++ version and set an error code variable if an exception occured.
This PR adds exception free templated versions of `pull_sample`, `pull_chunk_multiplexed` and `push_sample` that set the same error codes.