### PR TITLE
LabRecorder: Use std::thread instead of Boost.Thread, QFile instead of Boost.Filesystem

### DIFF
--- a/Apps/LabRecorder/.gitignore
+++ b/Apps/LabRecorder/.gitignore
@@ -1,3 +1,3 @@
 ui_*.h
-*.VC.*
-*.vcxproj*
+/build/
+/CMakeLists.txt.user

--- a/Apps/LabRecorder/.gitignore
+++ b/Apps/LabRecorder/.gitignore
@@ -1,3 +1,0 @@
-ui_*.h
-/build/
-/CMakeLists.txt.user

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -24,15 +24,13 @@ option(LABRECORDER_BOOST_TYPE_CONVERSIONS "Use boost for type conversions" Off)
 # GENERAL CONFIG #
 set(META_PROJECT_DESCRIPTION "Record LabStreamingLayer streams to XDF data file.")
 
-# THIRD PARTY LIBRARIES #
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
-# APPLICATION #
+find_package(Threads REQUIRED)
 
-# Target name
-set(target ${PROJECT_NAME})
-
-# Build executable
 add_executable(${PROJECT_NAME} MACOSX_BUNDLE WIN32
 	main.cpp
 	mainwindow.cpp
@@ -51,19 +49,13 @@ add_executable(testxdfwriter
 	xdfwriter.cpp
 )
 
-target_compile_features(${target} PRIVATE cxx_auto_type cxx_lambda_init_captures)
-
-find_package(Threads REQUIRED)
-
-target_link_libraries(${target}
-    PRIVATE
-    Qt5::Widgets
-    Threads::Threads
-    LSL::lsl
+target_link_libraries(${PROJECT_NAME}
+	PRIVATE
+	Qt5::Widgets
+	Threads::Threads
+	LSL::lsl
 )
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED On)
 
 # Test for floating point format and endianness
 try_run(IS_LITTLE_ENDIAN IS_IEC559
@@ -81,8 +73,8 @@ endif()
 if(LABRECORDER_BOOST_TYPE_CONVERSIONS OR NOT IS_LITTLE_ENDIAN OR NOT IS_IEC559)
 	message(STATUS "Trying to use Boost for type conversions")
 	find_package(Boost REQUIRED)
-	target_link_libraries(${target} PRIVATE Boost::boost)
-	target_compile_definitions(${target} PRIVATE EXOTIC_ARCH_SUPPORT)
+	target_link_libraries(${PROJECT_NAME} PRIVATE Boost::boost)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE EXOTIC_ARCH_SUPPORT)
 endif()
 
 # Enable xdfz support if Boost::iostreams and Boost.zlib (Windows) or plain zlib (Unix) was found
@@ -90,16 +82,19 @@ if(LABRECORDER_XDFZ)
 	find_package(Boost REQUIRED COMPONENTS iostreams)
 	if(WIN32)
 		find_package(Boost REQUIRED COMPONENTS zlib)
-		target_link_libraries(${target} PRIVATE Boost::iostreams Boost::zlib)
+		target_link_libraries(${PROJECT_NAME} PRIVATE Boost::iostreams Boost::zlib)
 	else()
 		find_package(ZLIB REQUIRED)
-		target_link_libraries(${target} PRIVATE Boost::iostreams ${ZLIB_LIBRARIES})
+		target_link_libraries(${PROJECT_NAME} PRIVATE Boost::iostreams ${ZLIB_LIBRARIES})
 	endif()
 	message(STATUS "Found zlib, enabling support for xdfz files")
-	target_compile_definitions(${target} PRIVATE XDFZ_SUPPORT=1)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE XDFZ_SUPPORT=1)
 endif()
 
-installLSLApp(${target})
-installLSLAuxFiles(${target} default_config.cfg)
+installLSLApp(${PROJECT_NAME})
+installLSLApp(testxdfwriter)
+installLSLAuxFiles(${PROJECT_NAME}
+	default_config.cfg
+)
 
 LSLGenerateCPackConfig()

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -1,16 +1,15 @@
-# CMake version
 cmake_minimum_required(VERSION 3.5)
 
 project(LabRecorder
-    LANGUAGES CXX
-	VERSION 1.1.2)
+	LANGUAGES CXX
+	VERSION 1.12.0)
 
-# load LSLAppBoilerplate if not done already
+# set up LSL if not done already
 if(NOT TARGET LSL::lsl)
 	# when building out of tree LSL_ROOT needs to be specified on the cmd line
 	file(TO_CMAKE_PATH "${LSL_INSTALL_ROOT}" LSL_INSTALL_ROOT)
 	list(APPEND LSL_INSTALL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/install")
-	find_package(LSL HINTS ${LSL_INSTALL_ROOT}/share/LSL/)
+	find_package(LSL HINTS ${LSL_INSTALL_ROOT}/share/LSL/ ${LSL_INSTALL_ROOT}/LSL/share/LSL QUIET)
 	if(NOT LSL_FOUND)
 		message(FATAL_ERROR "Precompiled LSL was not found. Set LSL_INSTALL_ROOT to the LSL installation path ( cmake -DLSL_INSTALL_ROOT=/path/to/installed/lsl)")
 	endif()
@@ -20,12 +19,6 @@ if(NOT TARGET LSL::lsl)
 endif()
 
 # GENERAL CONFIG #
-cmake_policy(SET CMP0028 NEW) # ENABLE CMP0028: Double colon in target name means ALIAS or IMPORTED target.
-cmake_policy(SET CMP0054 NEW) # ENABLE CMP0054: Only interpret if() arguments as variables or keywords when unquoted.
-cmake_policy(SET CMP0063 NEW) # ENABLE CMP0063: Honor visibility properties for all target types.
-cmake_policy(SET CMP0042 NEW) # ENABLE CMP0042: MACOSX_RPATH is enabled by default.
-
-# Meta information about the project
 set(META_PROJECT_DESCRIPTION "Record LabStreamingLayer streams to XDF data file.")
 
 # THIRD PARTY LIBRARIES #
@@ -34,7 +27,7 @@ find_package(Qt5 REQUIRED COMPONENTS Network Widgets)
 # APPLICATION #
 
 # Target name
-set(target LabRecorder)
+set(target ${PROJECT_NAME})
 
 # Build executable
 add_executable(${target}
@@ -47,38 +40,36 @@ add_executable(${target}
     recording.h
 	recording.cpp
 )
-target_compile_features(${target} PRIVATE cxx_auto_type)
+target_compile_features(${target} PRIVATE cxx_auto_type cxx_lambda_init_captures)
 
-find_package(Boost REQUIRED COMPONENTS filesystem iostreams thread)
-set(zlib_libs "")
+find_package(Threads REQUIRED)
+find_package(Boost REQUIRED OPTIONAL_COMPONENTS iostreams)
 if(WIN32)
 	find_package(Boost OPTIONAL_COMPONENTS zlib QUIET)
 	if(TARGET Boost::zlib)
-		set(zlib_libs "Boost::zlib")
-		message(STATUS "LabRecorder: Using Boost.zlib for xdfz support")
-
+		set(ZLIB_LIBRARIES Boost::zlib)
 	endif()
 else()
 	find_package(ZLIB QUIET)
-	if(ZLIB_FOUND)
-		message(STATUS "LabRecorder: Using zlib for xdfz support")
-		set(zlib_libs ${ZLIB_LIBRARIES})
-	endif()
 endif()
 
 target_link_libraries(${target}
     PRIVATE
     Qt5::Widgets
     Qt5::Network
-    Boost::filesystem
-    Boost::iostreams
-    Boost::thread
-    ${zlib_libs}
+	Boost::boost
+    Threads::Threads
     LSL::lsl
 )
 
-# Enable xdfz support if Boost.zlib (Windows) or plain zlib (Unix) was found
-if(${zlib_libs})
+# Enable xdfz support if Boost::iostreams and Boost.zlib (Windows) or plain zlib (Unix) was found
+if(ZLIB_LIBRARIES AND TARGET Boost::iostreams)
+	message(STATUS "Found zlib, enabling support for xdfz files")
+	target_link_libraries(${target}
+		PRIVATE
+		${ZLIB_LIBRARIES}
+		Boost::iostreams
+		)
 	target_compile_definitions(${target} PRIVATE XDFZ_SUPPORT=1)
 endif()
 

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT TARGET LSL::lsl)
 	list(APPEND LSL_INSTALL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../LSL/liblsl/build/install")
 	find_package(LSL HINTS ${LSL_INSTALL_ROOT}/share/LSL/ ${LSL_INSTALL_ROOT}/LSL/share/LSL QUIET)
 	if(NOT LSL_FOUND)
-		message(FATAL_ERROR "Precompiled LSL was not found. Set LSL_INSTALL_ROOT to the LSL installation path ( cmake -DLSL_INSTALL_ROOT=/path/to/installed/lsl)")
+		message(FATAL_ERROR "Precompiled LSL was not found. See https://github.com/labstreaminglayer/labstreaminglayer/blob/master/doc/BUILD.md#lsl_install_root for more information.")
 	endif()
 	list(APPEND CMAKE_MODULE_PATH ${LSL_DIR})
 	message(STATUS "Looking for LSLCMake in ${LSL_DIR}")
@@ -33,17 +33,24 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets)
 set(target ${PROJECT_NAME})
 
 # Build executable
-add_executable(${target}
-    MACOSX_BUNDLE
-    WIN32
-    main.cpp
-    mainwindow.cpp
-    mainwindow.h
-    mainwindow.ui
-    recording.h
+add_executable(${PROJECT_NAME} MACOSX_BUNDLE WIN32
+	main.cpp
+	mainwindow.cpp
+	mainwindow.h
+	mainwindow.ui
+	recording.h
 	recording.cpp
 	conversions.h
+	xdfwriter.h
+	xdfwriter.cpp
 )
+
+add_executable(testxdfwriter
+	test_xdf_writer.cpp
+	xdfwriter.h
+	xdfwriter.cpp
+)
+
 target_compile_features(${target} PRIVATE cxx_auto_type cxx_lambda_init_captures)
 
 find_package(Threads REQUIRED)

--- a/Apps/LabRecorder/CMakeLists.txt
+++ b/Apps/LabRecorder/CMakeLists.txt
@@ -18,11 +18,14 @@ if(NOT TARGET LSL::lsl)
 	include(LSLCMake)
 endif()
 
+option(LABRECORDER_XDFZ "use Boost.Iostreams for XDFZ support" Off)
+option(LABRECORDER_BOOST_TYPE_CONVERSIONS "Use boost for type conversions" Off)
+
 # GENERAL CONFIG #
 set(META_PROJECT_DESCRIPTION "Record LabStreamingLayer streams to XDF data file.")
 
 # THIRD PARTY LIBRARIES #
-find_package(Qt5 REQUIRED COMPONENTS Network Widgets)
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 # APPLICATION #
 
@@ -39,37 +42,53 @@ add_executable(${target}
     mainwindow.ui
     recording.h
 	recording.cpp
+	conversions.h
 )
 target_compile_features(${target} PRIVATE cxx_auto_type cxx_lambda_init_captures)
 
 find_package(Threads REQUIRED)
-find_package(Boost REQUIRED OPTIONAL_COMPONENTS iostreams)
-if(WIN32)
-	find_package(Boost OPTIONAL_COMPONENTS zlib QUIET)
-	if(TARGET Boost::zlib)
-		set(ZLIB_LIBRARIES Boost::zlib)
-	endif()
-else()
-	find_package(ZLIB QUIET)
-endif()
 
 target_link_libraries(${target}
     PRIVATE
     Qt5::Widgets
-    Qt5::Network
-	Boost::boost
     Threads::Threads
     LSL::lsl
 )
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED On)
+
+# Test for floating point format and endianness
+try_run(IS_LITTLE_ENDIAN IS_IEC559
+	${CMAKE_CURRENT_BINARY_DIR}
+	"${CMAKE_CURRENT_SOURCE_DIR}/test_iec559_and_little_endian.cpp"
+	CMAKE_FLAGS "-DCMAKE_CXX_STANDARD=14" "-DCMAKE_CXX_STANDARD_REQUIRED=On"
+	COMPILE_OUTPUT_VARIABLE IEC559_COMPILE)
+message(STATUS "Little endian: ${IS_LITTLE_ENDIAN}")
+message(STATUS "IEC559: ${IS_IEC559}")
+if(NOT IS_IEC559)
+	message(WARNING "IEC559 test: ${IEC559_COMPILE}")
+endif()
+
+
+if(LABRECORDER_BOOST_TYPE_CONVERSIONS OR NOT IS_LITTLE_ENDIAN OR NOT IS_IEC559)
+	message(STATUS "Trying to use Boost for type conversions")
+	find_package(Boost REQUIRED)
+	target_link_libraries(${target} PRIVATE Boost::boost)
+	target_compile_definitions(${target} PRIVATE EXOTIC_ARCH_SUPPORT)
+endif()
+
 # Enable xdfz support if Boost::iostreams and Boost.zlib (Windows) or plain zlib (Unix) was found
-if(ZLIB_LIBRARIES AND TARGET Boost::iostreams)
+if(LABRECORDER_XDFZ)
+	find_package(Boost REQUIRED COMPONENTS iostreams)
+	if(WIN32)
+		find_package(Boost REQUIRED COMPONENTS zlib)
+		target_link_libraries(${target} PRIVATE Boost::iostreams Boost::zlib)
+	else()
+		find_package(ZLIB REQUIRED)
+		target_link_libraries(${target} PRIVATE Boost::iostreams ${ZLIB_LIBRARIES})
+	endif()
 	message(STATUS "Found zlib, enabling support for xdfz files")
-	target_link_libraries(${target}
-		PRIVATE
-		${ZLIB_LIBRARIES}
-		Boost::iostreams
-		)
 	target_compile_definitions(${target} PRIVATE XDFZ_SUPPORT=1)
 endif()
 

--- a/Apps/LabRecorder/README.md
+++ b/Apps/LabRecorder/README.md
@@ -45,6 +45,3 @@ You should check the health of your device to be sure, however, for example usin
 
 If a device is displayed in red when you start recording (and it is checked), it will be added to the ongoing recording by the time when it comes online. This can be useful when a device can only be turned on while the recording is already in progress. Again, it is advisable to check that the device is in fact discoverable and added. The LabRecorder brings up a console window in the background which shows a list of all streams that are added to the recording -- this is a good place to check whether a late stream did get picked up successfully during a live recording.
 
-# Note for SCCN Users
-
-If you are at the Swartz Center you will probably want to install our preferred Python distribution, in particular if you intend to be developing for SNAP (our stimulus presentation environment). The files and instructions can be found at [ftp://sccn.ucsd.edu/pub/software/third_party/build_environment/](ftp://sccn.ucsd.edu/pub/software/third_party/build_environment/)

--- a/Apps/LabRecorder/conversions.h
+++ b/Apps/LabRecorder/conversions.h
@@ -1,0 +1,119 @@
+// Most target architectures are little-endian with IEC559/IEEE754 floats
+// This header provides conversion functions for all others and
+// functions to write binary data to streambufs
+
+#ifndef CONVERSIONS_H_
+#define CONVERSIONS_H_
+
+#include <cstdint>
+#include <streambuf>
+#include <vector>
+#include <limits>
+
+#ifdef EXOTIC_ARCH_SUPPORT
+#include <boost/version.hpp>
+
+// support for endianness and binary floating-point storage
+// this import scheme is part of the portable_archive code by
+// christian.pfligersdorffer@eos.info (under boost license)
+#include <boost/spirit/home/support/detail/math/fpclassify.hpp>
+// namespace alias fp_classify
+namespace fp = boost::spirit::math;
+
+#if BOOST_VERSION >= 105800
+#include <boost/endian/conversion.hpp>
+using boost::endian::native_to_little_inplace;
+#else
+#error "BOOST_VERSION >= 1.58 required"
+#endif
+
+// === writer functions ===
+// write an integer value in little endian
+// derived from portable archive code by christian.pfligersdorffer@eos.info (under boost license)
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value>::type write_little_endian(std::streambuf* dst, T t) {
+	native_to_little_inplace(t);
+	dst->sputn((char*)(&t), sizeof(t));
+}
+
+// write a floating-point value in little endian
+// derived from portable archive code by christian.pfligersdorffer@eos.info (under boost license)
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value>::type
+write_little_endian(std::streambuf* dst, T t) {
+	//Get a type big enough to hold
+	using traits = typename fp::detail::fp_traits<T>::type;
+	static_assert(sizeof(typename traits::bits) == sizeof(T), "floating point type can't be represented accurately");
+
+	typename traits::bits bits;
+	// remap to bit representation
+	switch (fp::fpclassify(t)) {
+	case FP_NAN: bits = traits::exponent | traits::mantissa; break;
+	case FP_INFINITE: bits = traits::exponent | (t < 0) * traits::sign; break;
+	case FP_SUBNORMAL: break;
+	case FP_ZERO: // note that floats can be ±0.0
+	case FP_NORMAL: traits::get_bits(t, bits); break;
+	default: bits = 0; break;
+	}
+	write_little_endian(dst, bits);
+}
+
+// store a sample's values to a stream (numeric version) */
+template <class T>
+inline void write_sample_values(std::streambuf* dst, const std::vector<T>& sample) {
+	// [Value1] .. [ValueN] */
+	for (const T s : sample) write_little_endian(dst, s);
+}
+
+#else
+
+static_assert(std::numeric_limits<float>::is_iec559,
+              "Non-IEC559/IEEE754-floats need EXOTIC_ARCH_SUPPORT defined");
+static_assert(std::numeric_limits<float>::has_denorm, "denormalized floats not supported");
+static_assert(sizeof(float) == 4, "Unexpected float size!");
+static_assert(sizeof(double) == 8, "Unexpected double size!");
+
+template <typename T>
+typename std::enable_if<sizeof(T) == 1>::type write_little_endian(std::streambuf* dst, T t) {
+	dst->sputc(t);
+}
+
+template <typename T>
+typename std::enable_if<sizeof(T) >= 2>::type write_little_endian(std::streambuf* dst, T t) {
+	dst->sputn(reinterpret_cast<const char*>(&t), sizeof(T));
+}
+
+template <class T>
+inline void write_sample_values(std::streambuf* dst, const std::vector<T>& sample) {
+	// [Value1] .. [ValueN] */
+	dst->sputn(reinterpret_cast<const char*>(sample.data()), sample.size() * sizeof(T));
+}
+#endif
+
+// write a variable-length integer (int8, int32, or int64)
+inline void write_varlen_int(std::streambuf* dst, uint64_t val) {
+	if (val < 256) {
+		dst->sputc(1);
+		dst->sputc(static_cast<uint8_t>(val));
+	} else if (val <= 4294967295) {
+		dst->sputc(4);
+		write_little_endian(dst, static_cast<uint32_t>(val));
+	} else {
+		dst->sputc(8);
+		write_little_endian(dst, static_cast<uint64_t>(val));
+	}
+}
+
+// store a sample's values to a stream (string version)
+template <>
+inline void write_sample_values(std::streambuf* dst, const std::vector<std::string>& sample) {
+	// [Value1] .. [ValueN] */
+	for (const std::string& s : sample) {
+		// [NumLengthBytes], [Length] (as varlen int)
+		write_varlen_int(dst, s.size());
+		// [StringContent] */
+		dst->sputn(s.data(), s.size());
+	}
+}
+
+#endif

--- a/Apps/LabRecorder/default_config.cfg
+++ b/Apps/LabRecorder/default_config.cfg
@@ -15,7 +15,7 @@ StorageLocation=C:/Recordings/CurrentStudy/exp%n/untitled.xdf
 ; The syntax is as in: RequiredStreams = "BioSemi (MyHostname)","PhaseSpace (MyHostname)","Eyelink (AnotherHostname)"
 ; where the format is identical to what the LabRecorder displays in the "Record from streams" list.
 
-RequiredStreams=
+;RequiredStreams="RequiredExample (PC)"
 SessionBlocks="T1", "T2", "T3"
 
 

--- a/Apps/LabRecorder/default_config.cfg
+++ b/Apps/LabRecorder/default_config.cfg
@@ -1,96 +1,32 @@
-﻿# === Storage Location ===
-# the default file name can be something like C:\\Recordings\\untitled.xdf, but can also contain a 
-# placeholder for a running number (incremented per experiment session) called %n, and a 
-# placeholder for a "block" label %b (if the config script provides a list of block names that 
-# consitute a session
-# The syntax is as in: StorageLocation = "C:\\Recordings\\subject%n\\block_%b.xdf"
+﻿; === Storage Location ===
+; the default file name can be something like C:\\Recordings\\untitled.xdf, but can also contain a 
+; placeholder for a running number (incremented per experiment session) called %n, and a 
+; placeholder for a "block" label %b (if the config script provides a list of block names that 
+; consitute a session
+; The syntax is as in: StorageLocation = "C:\\Recordings\\subject%n\\block_%b.xdf"
 
-StorageLocation=C:\Recordings\CurrentStudy\exp%n\untitled.xdf
+StorageLocation=C:/Recordings/CurrentStudy/exp%n/untitled.xdf
 
-#OnlineSync=["ActiChamp-0 (User-PC)" post_ALL]
+;OnlineSync=["ActiChamp-0 (User-PC)" post_ALL]
 
-# === Required Streams ===
-# This is optionally a list of streams that are required for the recording; 
-# a warning is issued if one of the streams is not present when the record button is pressed
-# The syntax is as in: RequiredStreams = ["BioSemi (MyHostname)","PhaseSpace (MyHostname)","Eyelink (AnotherHostname)"]
-# where the format is identical to what the LabRecorder displays in the "Record from streams" list.
+; === Required Streams ===
+; This is optionally a list of streams that are required for the recording; 
+; a warning is issued if one of the streams is not present when the record button is pressed
+; The syntax is as in: RequiredStreams = "BioSemi (MyHostname)","PhaseSpace (MyHostname)","Eyelink (AnotherHostname)"
+; where the format is identical to what the LabRecorder displays in the "Record from streams" list.
 
-RequiredStreams=[]
-OnlineSync=[]
-#OnlineSync=[ActiChamp-0 (DM-Laptop) post_ALL, LiveAmpSN-054211-0237 (User-PC) post_ALL ]
-
-# === Block Names ===
-# This is optionally a list of blocks that make up a recording session. The blocks are displayed in 
-# a list box where the experiment can select a block before pressing record. If used, the blocks 
-# may serve as a reminder of where they are in the experiment, but more practically, can be 
-# used to determine the file name of the recording. Power users can define scriptable actions 
-# associated with selecting a block or pressing Start/Stop for a given block (e.g., for remote 
-# control).
-# The syntax is as in: SessionBlocks = [Training,PreBaseline,MainSection,PostBaseline]
-
-SessionBlocks=[]
-
-# From here on, none of the following is currently implemented. 
-# It stays in case LabRecorder goes back to its previous python implementation, or
-# it a Lua interpreter ever gets rolled into the current C++ implementation.
-
-# === Extra checks to apply to some of the streams ===
-# Note that this is an optional advanced feature that is aimed at power users.
-# For a subset of streams, a list of [condition,errormessage,condition,errormessage, ...] can be 
-# given to inform the experimenter of possible problems with the recording setup (e.g., a device 
-# was mis-configured); the syntax of the condition strings is XPath 1.0 (applied to the meta-data 
-# of the stream) and the overall format for the ExtraCondtions variable is that of a Python 
-# dictionary.
-# See sample_config.cfg for an example of the syntax
-
-ExtraChecks={}
+RequiredStreams=
+SessionBlocks="T1", "T2", "T3"
 
 
+; === Block Names ===
+; This is optionally a list of blocks that make up a recording session. The blocks are displayed in 
+; a list box where the experiment can select a block before pressing record. If used, the blocks 
+; may serve as a reminder of where they are in the experiment, but more practically, can be 
+; used to determine the file name of the recording. Power users can define scriptable actions 
+; associated with selecting a block or pressing Start/Stop for a given block (e.g., for remote 
+; control).
+; The syntax is as in: SessionBlocks = "Training","PreBaseline","MainSection","PostBaseline"
 
-# === Optional script actions ===
-# Functions can be defined here that get called when the given action in the Experimenter GUI
-# is triggered. For example, thi can be used to remote-control an experiment program on the 
-# Subject's PC. If the function throws an exception, an warning message is presented to the 
-# user to alert him of a possible problem. The user can choose to continue recording anyway.
-# The script actions are implemented as Python functions; they may refer to the previously 
-# declared config variables. These functions will only be triggered when EnableScriptedActions
-# is set to True.
-
-# set this to true to enable the below remote-control scripts
-EnableScriptedActions = False
-# you also need to set the correct hostname/IP address that hosts your experiment program
-#SNAPHost = ("localhost",7897)
-
-#def on_init(self):
-#    print "Intitializing..."
-
-#def on_selectblock(self,blockname):    
-#    print "Loading block ", blockname, " in SNAP."    
-#    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-#    sock.settimeout(3)
-#    sock.connect(self.SNAPHost)
-#    sock.sendall("config " + blockname + "\n")
-#    sock.close()
-    
-#def on_startrecord(self,blockname,sessionnumber):
-#    print "Starting block in SNAP."    
-#    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-#    sock.settimeout(3)
-#    sock.connect(self.SNAPHost)
-#    sock.sendall("setup permutation = " + str(sessionnumber) + "\n")
-#    sock.sendall("start\n")
-#    sock.close()
-
-#def on_stoprecord(self,blockname,sessionnumber):
-#    print "Stopping block in SNAP."    
-#    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-#    sock.settimeout(3)
-#    sock.connect(self.SNAPHost)
-#    sock.sendall("stop\n")
-#    sock.close()
-
-#def on_pauserecord(self,blockname,sessionnumber):
-#    pass
-
-#def on_quit(self):
-#    pass
+OnlineSync="SendDataC (Testpc) post_ALL", "Test (Testpc) post_clocksync"
+; OnlineSync="ActiChamp-0 (DM-Laptop) post_ALL", "LiveAmpSN-054211-0237 (User-PC) post_ALL"

--- a/Apps/LabRecorder/main.cpp
+++ b/Apps/LabRecorder/main.cpp
@@ -5,7 +5,7 @@ int main(int argc, char *argv[])
 {
 
     // determine the startup config file...
-    std::string config_file = "default_config.cfg";
+	const char* config_file = "default_config.cfg";
     for (int k=1;k<argc;k++)
         if (std::string(argv[k]) == "-c" || std::string(argv[k]) == "--config")
             config_file = argv[k+1];

--- a/Apps/LabRecorder/mainwindow.cpp
+++ b/Apps/LabRecorder/mainwindow.cpp
@@ -3,22 +3,21 @@
 
 #include <string>
 #include <vector>
-#include <QSettings>
 #include <QDateTime>
+#include <QDebug>
 #include <QFileDialog>
 #include <QMessageBox>
-#include <QDebug>
-#include <fstream>
+#include <QSettings>
 
 // recording class
 #include "recording.h"
 
-MainWindow::MainWindow(QWidget *parent, const std::string &config_file) :
+MainWindow::MainWindow(QWidget *parent, const char* config_file) :
 QMainWindow(parent),
 ui(new Ui::MainWindow) {
 
 	ui->setupUi(this);
-	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);
+	connect(ui->actionQuit, &QAction::triggered, this, &MainWindow::close);
 	connect(ui->actionLoadConfig, &QAction::triggered, [this](){
 		this->load_config(QFileDialog::getOpenFileName(this,"Load Configuration File","","Configuration Files (*.cfg)"));
 	});
@@ -26,7 +25,7 @@ ui(new Ui::MainWindow) {
 		this->save_config(QFileDialog::getSaveFileName(this, "Save Configuration File", "", "Configuration Files (*.cfg)"));
 	});
 	connect(ui->browseButton, &QPushButton::clicked, [this](){
-			this->ui->locationEdit->setText(QFileDialog::getSaveFileName(this,"Save recordings as...", "untitled.xdf", "XDF recordings (*.xdf)"));
+		this->ui->locationEdit->setText(QFileDialog::getSaveFileName(this,"Save recordings as...", "untitled.xdf", "XDF recordings (*.xdf)"));
 	});
 	connect(ui->blockList, static_cast<void(QComboBox::*)(const QString &)>(&QComboBox::activated), this, &MainWindow::blockSelected);
 	connect(ui->refreshButton, &QPushButton::clicked, this, &MainWindow::refreshStreams);
@@ -38,7 +37,7 @@ ui(new Ui::MainWindow) {
 		QMessageBox::about(this, "About LabRecorder", infostr);
 	});
 
-	load_config(config_file.c_str());
+	load_config(config_file);
 
 	timer.reset(new QTimer(this));
 	connect(&*timer, &QTimer::timeout, this, &MainWindow::statusUpdate);
@@ -46,6 +45,8 @@ ui(new Ui::MainWindow) {
 	//startTime = (int)lsl::local_clock();
 
 }
+
+MainWindow::~MainWindow() noexcept = default;
 
 void MainWindow::statusUpdate() const {
 	if(currentRecording) {
@@ -221,11 +222,11 @@ void MainWindow::startRecording() {
 		if(checked.isEmpty()) {
 			QMessageBox msgBox(QMessageBox::Warning, "No streams selected",
 							   "You have selected no streams", QMessageBox::Yes | QMessageBox::No,
-				                   this);
-				msgBox.setInformativeText("Do you want to start recording anyway?");
-				msgBox.setDefaultButton(QMessageBox::No);
-				if(msgBox.exec()!=QMessageBox::Yes)
-					return;
+							   this);
+			msgBox.setInformativeText("Do you want to start recording anyway?");
+			msgBox.setDefaultButton(QMessageBox::No);
+			if(msgBox.exec()!=QMessageBox::Yes)
+				return;
 		}
 
 		// determine the experiment number block

--- a/Apps/LabRecorder/mainwindow.cpp
+++ b/Apps/LabRecorder/mainwindow.cpp
@@ -19,14 +19,14 @@ ui(new Ui::MainWindow) {
 
 	ui->setupUi(this);
 	connect(ui->actionQuit, &QAction::triggered, this, &QMainWindow::close);
-	connect(ui->actionLoadConfig, &QAction::triggered, [&](){
-		QString sel = QFileDialog::getOpenFileName(this,"Load Configuration File","","Configuration Files (*.cfg)");
-		if (!sel.isEmpty()) load_config(sel);
+	connect(ui->actionLoadConfig, &QAction::triggered, [this](){
+		this->load_config(QFileDialog::getOpenFileName(this,"Load Configuration File","","Configuration Files (*.cfg)"));
 	});
-	connect(ui->browseButton, &QPushButton::clicked, [&](){
-		QString sel = QFileDialog::getSaveFileName(this,"Save recordings as...", "untitled.xdf", "XDF recordings (*.xdf);;XDF compressed recordings (*.xdfz)");
-		if (!sel.isEmpty())
-			ui->locationEdit->setText(sel);
+	connect(ui->actionSaveConfig, &QAction::triggered, [this](){
+		this->save_config(QFileDialog::getSaveFileName(this, "Save Configuration File", "", "Configuration Files (*.cfg)"));
+	});
+	connect(ui->browseButton, &QPushButton::clicked, [this](){
+			this->ui->locationEdit->setText(QFileDialog::getSaveFileName(this,"Save recordings as...", "untitled.xdf", "XDF recordings (*.xdf)"));
 	});
 	connect(ui->blockList, static_cast<void(QComboBox::*)(const QString &)>(&QComboBox::activated), this, &MainWindow::blockSelected);
 	connect(ui->refreshButton, &QPushButton::clicked, this, &MainWindow::refreshStreams);
@@ -147,6 +147,8 @@ void MainWindow::save_config(QString filename)
 {
 	QSettings settings(filename, QSettings::Format::IniFormat);
 	settings.setValue("StorageLocation", ui->locationEdit->text());
+	qInfo() << requiredStreams;
+	settings.setValue("RequiredStreams", requiredStreams);
 	// Stub.
 }
 

--- a/Apps/LabRecorder/mainwindow.cpp
+++ b/Apps/LabRecorder/mainwindow.cpp
@@ -29,6 +29,8 @@ ui(new Ui::MainWindow) {
 	});
 	connect(ui->blockList, static_cast<void(QComboBox::*)(const QString &)>(&QComboBox::activated), this, &MainWindow::blockSelected);
 	connect(ui->refreshButton, &QPushButton::clicked, this, &MainWindow::refreshStreams);
+	connect(ui->selectAllButton, &QPushButton::clicked, this, &MainWindow::selectAllStreams);
+	connect(ui->selectNoneButton, &QPushButton::clicked, this, &MainWindow::selectNoStreams);
 	connect(ui->startButton, &QPushButton::clicked, this, &MainWindow::startRecording);
 	connect(ui->stopButton, &QPushButton::clicked, this, &MainWindow::stopRecording);
 	connect(ui->actionAbout, &QAction::triggered, [this](){
@@ -196,7 +198,7 @@ std::vector<lsl::stream_info> MainWindow::refreshStreams() {
 }
 
 void MainWindow::startRecording() {
-	
+
 	if (!currentRecording ) {
 
 		// automatically refresh streams
@@ -302,6 +304,20 @@ void MainWindow::stopRecording() {
 		ui->stopButton->setEnabled(false);
 		statusBar()->showMessage("Stopped");
 
+	}
+}
+
+void MainWindow::selectAllStreams() {
+	for(int i=0; i<ui->streamList->count(); i++) {
+		QListWidgetItem* item = ui->streamList->item(i);
+		item->setCheckState(Qt::Checked);
+	}
+}
+
+void MainWindow::selectNoStreams() {
+	for(int i=0; i<ui->streamList->count(); i++) {
+		QListWidgetItem* item = ui->streamList->item(i);
+		item->setCheckState(Qt::Unchecked);
 	}
 }
 

--- a/Apps/LabRecorder/mainwindow.h
+++ b/Apps/LabRecorder/mainwindow.h
@@ -17,8 +17,8 @@
 class recording;
 
 class RecorderItem {
-	
-public: 
+
+public:
 	QListWidgetItem listItem;
 	std::string uid;
 };
@@ -38,15 +38,17 @@ private slots:
 	std::vector<lsl::stream_info> refreshStreams(void);
 	void startRecording(void);
 	void stopRecording(void);
+	void selectAllStreams();
+	void selectNoStreams();
 
 private:
 	QSet<QString> getCheckedStreams() const;
 
 	std::unique_ptr<recording> currentRecording;
-	
+
 	int startTime;
 	std::unique_ptr<QTimer> timer;
- 
+
 	int currentTrial;
 	QString currentBlock;
 
@@ -59,7 +61,7 @@ private:
 	// function for loading config file
 	void load_config(QString filename);
 	void save_config(QString filename);
-    
+
 	std::unique_ptr<Ui::MainWindow> ui;	// window pointer
 };
 

--- a/Apps/LabRecorder/mainwindow.h
+++ b/Apps/LabRecorder/mainwindow.h
@@ -8,6 +8,7 @@
 #include <QCloseEvent>
 #include <QListWidget>
 #include <QTimer>
+#include <QStringList>
 
 #ifdef __WIN32
 
@@ -41,34 +42,32 @@ public:
 private slots:
 	void statusUpdate(void) const;
 	void closeEvent(QCloseEvent *ev) override;
-	void blockSelected(QListWidgetItem *item);
+	void blockSelected(const QString& block);
 	void refreshStreams(void);
 	void startRecording(void);
 	void stopRecording(void);
 
 private:
-
-	bool currentlyRecording;
-	recording *currentRecording;
+	std::unique_ptr<recording> currentRecording;
 	
 	int startTime;
 	std::unique_ptr<QTimer> timer;
  
 	int currentTrial;
-	std::string currentBlock;
+	QString currentBlock;
 
 	std::vector<lsl::stream_info> resolvedStreams;
 	std::vector<lsl::stream_info> checkedStreams;
-	std::vector<std::string> requiredStreams;
-	std::vector<std::string> onlineSyncStreams;
+	QStringList requiredStreams;
 	std::map<std::string, int> syncOptionsByStreamName;
-	std::vector<std::string> missingStreams;
+	QStringList missingStreams;
 
-	std::string recFilename;
+	QString recFilename;
 	FILE *p_recFile;
 
 	// function for loading config file
-	void load_config(const std::string &filename);
+	void load_config(QString filename);
+	void save_config(QString filename);
     
 	std::unique_ptr<Ui::MainWindow> ui;	// window pointer
 };

--- a/Apps/LabRecorder/mainwindow.h
+++ b/Apps/LabRecorder/mainwindow.h
@@ -63,7 +63,6 @@ private:
 	QSet<QString> missingStreams;
 
 	QString recFilename;
-	FILE *p_recFile;
 
 	// function for loading config file
 	void load_config(QString filename);

--- a/Apps/LabRecorder/mainwindow.h
+++ b/Apps/LabRecorder/mainwindow.h
@@ -43,11 +43,13 @@ private slots:
 	void statusUpdate(void) const;
 	void closeEvent(QCloseEvent *ev) override;
 	void blockSelected(const QString& block);
-	void refreshStreams(void);
+	std::vector<lsl::stream_info> refreshStreams(void);
 	void startRecording(void);
 	void stopRecording(void);
 
 private:
+	QSet<QString> getCheckedStreams() const;
+
 	std::unique_ptr<recording> currentRecording;
 	
 	int startTime;
@@ -56,11 +58,9 @@ private:
 	int currentTrial;
 	QString currentBlock;
 
-	std::vector<lsl::stream_info> resolvedStreams;
-	std::vector<lsl::stream_info> checkedStreams;
 	QStringList requiredStreams;
 	std::map<std::string, int> syncOptionsByStreamName;
-	QStringList missingStreams;
+	QSet<QString> missingStreams;
 
 	QString recFilename;
 	FILE *p_recFile;

--- a/Apps/LabRecorder/mainwindow.h
+++ b/Apps/LabRecorder/mainwindow.h
@@ -4,23 +4,17 @@
 // Qt
 #include "ui_mainwindow.h"
 
+#include <memory>
 #include <QMainWindow>
 #include <QCloseEvent>
 #include <QListWidget>
 #include <QTimer>
 #include <QStringList>
 
-#ifdef __WIN32
-
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#endif
-
 // LSL
 #include <lsl_cpp.h>
 
-// recording class
-#include "recording.h"
+class recording;
 
 class RecorderItem {
 	
@@ -29,15 +23,13 @@ public:
 	std::string uid;
 };
 
-namespace Ui {
-class MainWindow;
-}
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent,const std::string &config_file);
+	explicit MainWindow(QWidget *parent, const char* config_file);
+	~MainWindow() noexcept override;
 
 private slots:
 	void statusUpdate(void) const;
@@ -70,7 +62,5 @@ private:
     
 	std::unique_ptr<Ui::MainWindow> ui;	// window pointer
 };
-
-
 
 #endif // MAINWINDOW_H

--- a/Apps/LabRecorder/mainwindow.ui
+++ b/Apps/LabRecorder/mainwindow.ui
@@ -185,6 +185,12 @@
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
           </spacer>
          </item>
         </layout>
@@ -208,6 +214,7 @@
      <string>&amp;File</string>
     </property>
     <addaction name="actionLoadConfig"/>
+    <addaction name="actionSaveConfig"/>
     <addaction name="actionQuit"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
@@ -239,6 +246,11 @@
   <action name="actionAbout">
    <property name="text">
     <string>&amp;About</string>
+   </property>
+  </action>
+  <action name="actionSaveConfig">
+   <property name="text">
+    <string>Save configuration</string>
    </property>
   </action>
  </widget>

--- a/Apps/LabRecorder/mainwindow.ui
+++ b/Apps/LabRecorder/mainwindow.ui
@@ -100,6 +100,24 @@
           </widget>
          </item>
          <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QPushButton" name="selectAllButton">
+             <property name="text">
+              <string>Select All</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="selectNoneButton">
+             <property name="text">
+              <string>Select None</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
           <widget class="QPushButton" name="refreshButton">
            <property name="text">
             <string>Update</string>

--- a/Apps/LabRecorder/mainwindow.ui
+++ b/Apps/LabRecorder/mainwindow.ui
@@ -28,10 +28,6 @@
            <property name="text">
             <string>Start</string>
            </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../../../record.png</normaloff>../../../record.png</iconset>
-           </property>
            <property name="shortcut">
             <string>Ctrl+S</string>
            </property>
@@ -169,7 +165,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QListWidget" name="blockList"/>
+          <widget class="QComboBox" name="blockList"/>
          </item>
          <item>
           <widget class="QCheckBox" name="enableScriptedActionsCheck">
@@ -183,6 +179,13 @@
             <bool>true</bool>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>
@@ -211,7 +214,7 @@
     <property name="title">
      <string>He&amp;lp</string>
     </property>
-    <addaction name="actionComing_Soon"/>
+    <addaction name="actionAbout"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuHelp"/>
@@ -219,7 +222,7 @@
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionLoadConfig">
    <property name="text">
-    <string>Load configuration...</string>
+    <string>&amp;Load configuration...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
@@ -227,7 +230,7 @@
   </action>
   <action name="actionQuit">
    <property name="text">
-    <string>Quit</string>
+    <string>&amp;Quit</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
@@ -235,12 +238,7 @@
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About</string>
-   </property>
-  </action>
-  <action name="actionComing_Soon">
-   <property name="text">
-    <string>Coming Soon... :-)</string>
+    <string>&amp;About</string>
    </property>
   </action>
  </widget>

--- a/Apps/LabRecorder/recording.cpp
+++ b/Apps/LabRecorder/recording.cpp
@@ -1,4 +1,5 @@
 #include "recording.h"
+#include "conversions.h"
 
 #include <set>
 #include <sstream>
@@ -73,43 +74,6 @@ inline void timed_join_or_detach(std::list<thread_p>& threads, std::chrono::mill
 		threads.clear();
 	}
 }
-
-// Utilies for writing binary data to files
-
-// write a variable-length integer (int8, int32, or int64)
-inline void write_varlen_int(std::streambuf* dst, uint64_t val) {
-	if (val < 256) {
-		dst->sputc(1);
-		dst->sputc(static_cast<uint8_t>(val));
-	} else if (val <= 4294967295) {
-		dst->sputc(4);
-		write_little_endian(dst, static_cast<uint32_t>(val));
-	} else {
-		dst->sputc(8);
-		write_little_endian(dst, static_cast<uint64_t>(val));
-	}
-}
-
-// store a sample's values to a stream (numeric version) */
-template <class T>
-inline void write_sample_values(std::streambuf* dst, const std::vector<T>& sample) {
-	// [Value1] .. [ValueN] */
-	for (const T s : sample) write_little_endian(dst, s);
-}
-
-// store a sample's values to a stream (string version)
-template <>
-inline void write_sample_values(std::streambuf* dst, const std::vector<std::string>& sample) {
-	// [Value1] .. [ValueN] */
-	for (const std::string& s : sample) {
-		// [NumLengthBytes], [Length] (as varlen int)
-		write_varlen_int(dst, s.size());
-		// [StringContent] */
-		dst->sputn(s.data(), s.size());
-	}
-}
-
-
 
 recording::recording(const std::string& filename, const std::vector<lsl::stream_info>& streams, const std::vector<std::string>& watchfor, std::map<std::string, int> syncOptions, bool collect_offsets):
     offsets_enabled_(collect_offsets),
@@ -226,7 +190,7 @@ void recording::record_from_streaminfo(const lsl::stream_info& src, bool phase_l
 			// generate the [StreamHeader] chunk contents...
 			std::ostringstream hdr_content;
 			// [StreamId]
-			write_little_endian(hdr_content.rdbuf(),streamid);
+			write_little_endian(hdr_content.rdbuf(), streamid);
 			// [Content]
 			// retrieve the stream header & get its XML version
 			info = in->info();
@@ -255,10 +219,10 @@ void recording::record_from_streaminfo(const lsl::stream_info& src, bool phase_l
 				typed_transfer_loop<char>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);
 				break;
 			case lsl::cf_int16:
-				typed_transfer_loop<boost::int16_t>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);
+				typed_transfer_loop<int16_t>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);
 				break;
 			case lsl::cf_int32:
-				typed_transfer_loop<boost::int32_t>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);
+				typed_transfer_loop<int32_t>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);
 				break;
 			case lsl::cf_float32:
 				typed_transfer_loop<float>(streamid,info.nominal_srate(),in,first_timestamp,last_timestamp,sample_count);

--- a/Apps/LabRecorder/test_iec559_and_little_endian.cpp
+++ b/Apps/LabRecorder/test_iec559_and_little_endian.cpp
@@ -1,0 +1,18 @@
+#include <limits>
+#include <cstdint>
+
+// Endianness and float format test case
+// compilation fails if floats are weird,
+// returns endianness at runtime
+
+static_assert(std::numeric_limits<float>::is_iec559,
+              "Non-IEC559/IEEE754-floats need EXOTIC_ARCH_SUPPORT defined");
+static_assert(std::numeric_limits<float>::has_denorm, "denormalized floats not supported");
+static_assert(sizeof(float) == 4, "Unexpected float size!");
+static_assert(sizeof(double) == 8, "Unexpected double size!");
+
+int main(){
+	const uint32_t test_val = 0x01020304;
+	// return 0 if big endian, 1 if little endian
+	return *reinterpret_cast<const char*>(&test_val) == 0x04;
+}

--- a/Apps/LabRecorder/test_xdf_writer.cpp
+++ b/Apps/LabRecorder/test_xdf_writer.cpp
@@ -1,0 +1,61 @@
+#include "xdfwriter.h"
+
+int main(int argc, char** argv) {
+	XDFWriter w("test.xdf");
+	const uint32_t sid = 0x02C0FFEE;
+	const std::string footer(
+	    "<?xml version=\"1.0\"?>"
+	    "<info>"
+	    "<first_timestamp>5.1</first_timestamp>"
+	    "<last_timestamp>5.9</last_timestamp>"
+	    "<sample_count>9</sample_count>"
+	    "<clock_offsets>"
+	    "<offset><time>50979.7660030605</time><value>-3.436503902776167e-06</value></offset>"
+	    "</clock_offsets></info>");
+	w.write_stream_header(0, "<?xml version=\"1.0\"?>"
+	                         "<info>"
+	                         "<name>SendDataC</name>"
+	                         "<type>EEG</type>"
+	                         "<channel_count>3</channel_count>"
+	                         "<nominal_srate>10</nominal_srate>"
+	                         "<channel_format>int16</channel_format>"
+	                         "<created_at>50942.723319709003</created_at>"
+	                         "</info>");
+	w.write_stream_header(sid, "<?xml version=\"1.0\"?>"
+	                           "<info>"
+	                           "<name>SendDataString</name>"
+	                           "<type>StringMarker</type>"
+	                           "<channel_count>1</channel_count>"
+	                           "<nominal_srate>10</nominal_srate>"
+	                           "<channel_format>string</channel_format>"
+	                           "<created_at>50942.723319709003</created_at>"
+	                           "</info>");
+	w.write_boundary_chunk();
+
+	// write a single int16_t sample
+	w.write_data_chunk(0, {5.1}, std::vector<int16_t>{0xC0, 0xFF, 0xEE}, 3);
+
+	// write a single std::string sample with a length > 127
+	w.write_data_chunk(sid, {5.1}, std::vector<std::string>{footer}, 1);
+
+	// write multiple samples
+	std::vector<double> ts{5.2, 0, 0, 5.5};
+	std::vector<int16_t> data{12, 22, 32, 13, 23, 33, 14, 24, 34, 15, 25, 35};
+	std::vector<std::string> data_str{"Hello", "World", "from", "LSL"};
+	w.write_data_chunk(0, ts, data, 3);
+	w.write_data_chunk(sid, ts, data_str, 1);
+
+	// write data from nested vectors
+	ts = std::vector<double>{5.6,0,0,0};
+	std::vector<std::vector<int16_t>> data2{{12, 22, 32}, {13, 23, 33}, {14, 24, 34}, {15, 25, 35}};
+	std::vector<std::vector<std::string>> data2_str{{"Hello"}, {"World"}, {"from"}, {"LSL"}};
+	w.write_data_chunk_nested(0, ts, data2);
+	w.write_data_chunk_nested(sid, ts, data2_str);
+
+	w.write_boundary_chunk();
+	w.write_stream_offset(0, 6, -.1);
+	w.write_stream_offset(sid, 5, -.2);
+
+	w.write_stream_footer(0, footer);
+	w.write_stream_footer(sid, footer);
+}

--- a/Apps/LabRecorder/xdfwriter.cpp
+++ b/Apps/LabRecorder/xdfwriter.cpp
@@ -1,0 +1,85 @@
+#include "xdfwriter.h"
+#include <iostream>
+
+void write_timestamp(std::ostream& out, double ts) {
+	// [TimeStampBytes] (0 for no time stamp)
+	if (ts == 0)
+		out.put(0);
+	else {
+		// [TimeStampBytes]
+		out.put(8);
+		// [TimeStamp]
+		write_little_endian(out, ts);
+	}
+}
+
+XDFWriter::XDFWriter(const std::string& filename)
+#ifndef XDFZ_SUPPORT
+    : file_(filename, std::ios::binary | std::ios::trunc)
+#endif
+{
+	// open file stream
+#ifdef XDFZ_SUPPORT
+	if (boost::iends_with(filename, ".xdfz")) file_.push(boost::iostreams::zlib_compressor());
+	file_.push(
+	    boost::iostreams::file_descriptor_sink(filename, std::ios::binary | std::ios::trunc));
+#endif
+	// [MagicCode]
+	file_ << "XDF:";
+	// [FileHeader] chunk
+	_write_chunk(chunk_tag_t::fileheader,
+	             "<?xml version=\"1.0\"?><info><version>1.0</version></info>");
+}
+
+void XDFWriter::_write_chunk(chunk_tag_t tag, const std::string& content,
+                             const streamid_t* streamid_p) {
+	// Write the chunk header
+	_write_chunk_header(tag, content.length(), streamid_p);
+	// [Content]
+	file_ << content;
+}
+
+void XDFWriter::_write_chunk_header(chunk_tag_t tag, std::size_t len,
+                                    const streamid_t* streamid_p) {
+	len += sizeof(chunk_tag_t);
+	if (streamid_p) len += sizeof(streamid_t);
+	// std::cout << "Writing chunk len " << len << ' ' <<
+	// (streamid_p?std::to_string(*streamid_p):"") << std::endl;
+
+	// [Length] (variable-length integer, content + 2 bytes for the tag
+	// + 2 bytes if the streamid is being written
+	write_varlen_int(file_, len);
+	// [Tag]
+	write_little_endian(file_, static_cast<uint16_t>(tag));
+	// Optional: [StreamId]
+	if (streamid_p) write_little_endian(file_, *streamid_p);
+}
+
+void XDFWriter::write_stream_header(streamid_t streamid, const std::string& content) {
+	std::lock_guard<std::mutex> lock(write_mut);
+	_write_chunk(chunk_tag_t::streamheader, content, &streamid);
+}
+
+void XDFWriter::write_stream_footer(streamid_t streamid, const std::string& content) {
+	std::lock_guard<std::mutex> lock(write_mut);
+	_write_chunk(chunk_tag_t::streamfooter, content, &streamid);
+}
+
+void XDFWriter::write_stream_offset(streamid_t streamid, double now, double offset) {
+	std::lock_guard<std::mutex> lock(write_mut);
+	const auto len = sizeof(now) + sizeof(offset);
+	_write_chunk_header(chunk_tag_t::clockoffset, len, &streamid);
+	// [CollectionTime]
+	write_little_endian(file_, now - offset);
+	// [OffsetValue]
+	write_little_endian(file_, offset);
+}
+
+void XDFWriter::write_boundary_chunk() {
+	std::lock_guard<std::mutex> lock(write_mut);
+	// the signature of the boundary chunk (next chunk begins right after this)
+	const uint8_t boundary_uuid[] = {0x43, 0xA5, 0x46, 0xDC, 0xCB, 0xF5, 0x41, 0x0F,
+	                                 0xB3, 0x0E, 0xD5, 0x46, 0x73, 0x83, 0xCB, 0xE4};
+	_write_chunk_header(chunk_tag_t::boundary, sizeof(boundary_uuid));
+	write_sample_values(file_, boundary_uuid, sizeof(boundary_uuid));
+}

--- a/Apps/LabRecorder/xdfwriter.h
+++ b/Apps/LabRecorder/xdfwriter.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "conversions.h"
+
+#include <cassert>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#ifdef XDFZ_SUPPORT
+#include <boost/iostreams/filtering_stream.hpp>
+using outfile_t = boost::iostreams::filtering_ostream;
+#else
+#include <fstream>
+using outfile_t = std::ofstream;
+#endif
+
+using streamid_t = uint32_t;
+
+// the currently defined chunk tags
+enum class chunk_tag_t : uint16_t {
+	fileheader = 1,   // FileHeader chunk
+	streamheader = 2, // StreamHeader chunk
+	samples = 3,      // Samples chunk
+	clockoffset = 4,  // ClockOffset chunk
+	boundary = 5,     // Boundary chunk
+	streamfooter = 6, // StreamFooter chunk
+	undefined = 0
+};
+
+template <typename T> class PtrArrayWrapper {
+	const T* ptr_;
+	const std::size_t len_;
+
+public:
+	using value_type = T;
+	PtrArrayWrapper(const T* ptr, std::size_t len) : ptr_(ptr), len_(len) {}
+	PtrArrayWrapper(const std::vector<T>& vec) : ptr_(vec.cbegin()), len_(vec.size()) {}
+	std::size_t size() const noexcept { return len_; }
+	const T* cend() const noexcept { return ptr_ + len_; }
+	const T* cbegin() const noexcept { return ptr_; }
+	PtrArrayWrapper(const PtrArrayWrapper&) noexcept = default;
+	PtrArrayWrapper(PtrArrayWrapper&&) noexcept = default;
+	~PtrArrayWrapper() noexcept = default;
+};
+
+class XDFWriter {
+private:
+	outfile_t file_;
+	void _write_chunk_header(chunk_tag_t tag, std::size_t length,
+	                         const streamid_t* streamid_p = nullptr);
+
+	std::mutex write_mut;
+
+	template <typename T>
+	void _sample_chunk_writer(streamid_t streamid, const double* timestamps, const T* chunk,
+	                          std::size_t n_samples, std::size_t n_channels);
+
+	// write a generic chunk
+	void _write_chunk(chunk_tag_t tag, const std::string& content,
+	                  const streamid_t* streamid_p = nullptr);
+
+public:
+	XDFWriter(const std::string& filename);
+
+	template <typename T>
+	void write_data_chunk(streamid_t streamid, const std::vector<double>& timestamps,
+	                             const T* chunk, uint32_t n_samples, uint32_t n_channels);
+	template <typename T>
+	void write_data_chunk(streamid_t streamid, const std::vector<double>& timestamps,
+	                             const std::vector<T>& chunk, uint32_t n_channels) {
+		assert(timestamps.size() * n_channels == chunk.size());
+		write_data_chunk(streamid, timestamps, chunk.data(), timestamps.size(), n_channels);
+	}
+	template <typename T>
+	void write_data_chunk_nested(streamid_t streamid, const std::vector<double>& timestamps,
+	                             const std::vector<std::vector<T>>& chunk);
+
+	void write_stream_header(streamid_t streamid, const std::string& content);
+	void write_stream_footer(streamid_t streamid, const std::string& content);
+	void write_stream_offset(streamid_t streamid, double now, double offset);
+	void write_boundary_chunk();
+};
+
+inline void write_ts(std::ostream& out, double ts) {
+	// write timestamp
+	if (ts == 0)
+		out.put(0);
+	else {
+		// [TimeStampBytes]
+		out.put(8);
+		// [TimeStamp]
+		write_little_endian(out, ts);
+	}
+}
+
+template <typename T>
+void XDFWriter::write_data_chunk(streamid_t streamid, const std::vector<double>& timestamps,
+                                        const T* chunk, uint32_t n_samples, uint32_t n_channels) {
+	/**
+	  Samples data chunk: [Tag 3] [VLA ChunkLen] [StreamID] [VLA NumSamples]
+	  [NumSamples x [VLA TimestampLen] [TimeStampLen]
+	  [NumSamples x NumChannels Sample]
+	  */
+	if (n_samples == 0) return;
+	if (timestamps.size() != n_samples) throw std::runtime_error("timestamp / sample count mismatch");
+
+	// generate [Samples] chunk contents...
+
+	auto len = 1 + sizeof(n_samples);
+	std::ostringstream out;
+	for (double ts: timestamps) {
+		write_ts(out, ts);
+		// write sample, get the current position in the chunk array back
+		chunk = write_sample_values(out, chunk, n_channels);
+	}
+	const std::string outstr(out.str());
+	len += outstr.size();
+
+	std::lock_guard<std::mutex> lock(write_mut);
+	_write_chunk_header(chunk_tag_t::samples, len, &streamid);
+	write_fixlen_int(file_, n_samples);
+	file_ << outstr;
+}
+
+template <typename T>
+void XDFWriter::write_data_chunk_nested(streamid_t streamid, const std::vector<double>& timestamps,
+                                        const std::vector<std::vector<T>>& chunk) {
+	if (chunk.size() == 0) return;
+	if (timestamps.size() != chunk.size()) throw std::runtime_error("timestamp / sample count mismatch");
+	auto n_channels = chunk[0].size();
+
+	// generate [Samples] chunk contents...
+
+	auto len = 1 + sizeof(chunk.size());
+	std::ostringstream out;
+	auto sample_it = chunk.cbegin();
+	for (double ts: timestamps) {
+		assert(n_channels == sample_it->size());
+		write_ts(out, ts);
+		// write sample, get the current position in the chunk array back
+		write_sample_values(out, sample_it->data(), n_channels);
+		sample_it++;
+	}
+	const std::string outstr(out.str());
+	len += outstr.size();
+
+	std::lock_guard<std::mutex> lock(write_mut);
+	_write_chunk_header(chunk_tag_t::samples, len, &streamid);
+	write_fixlen_int(file_, chunk.size());
+	file_ << outstr;
+}


### PR DESCRIPTION
Finding and linking to Boost is a major hassle on Windows, so this PR uses Qt (which is required anyway) and `std::thread` ~so only Boost headers have to be installed~.

In case anyone wants to test it without compiling it first, CI-builds are available for [OS X](https://dl.bintray.com/labstreaminglayer/LSL/LabRecorder-1.12.0-OSX64.dmg), [Windows](https://dl.bintray.com/labstreaminglayer/LSL/LabRecorder_1.12.0-Win64.zip) and [Linux](https://dl.bintray.com/labstreaminglayer/LSL/).

Things to be done:
- [X] port Boost.Thread to std::thread
- [X] port Boost.PropertyTree to QSettings
- [X] port Boost.Filesystem to QFile
- [x] move big-endian / non-iec-559-support to a separate header
- [x] detect big-endian / non-iec-559 architectures at build time
- [x] add a testcase for binary file writing code