### PR TITLE
Use stable standard integer types

### DIFF
--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -547,46 +547,46 @@ extern LIBLSL_C_API int32_t lsl_push_sample_vtp(lsl_outlet out, const void *data
 *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
 * @return Error code of the operation (usually attributed to the wrong data type).
 */
-extern LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_l(lsl_outlet out, const long *data, unsigned long data_elements);
-extern LIBLSL_C_API int lsl_push_chunk_lt(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int lsl_push_chunk_ltp(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp, int pushthrough);
-extern LIBLSL_C_API int lsl_push_chunk_ltn(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int lsl_push_chunk_ltnp(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps, int pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const char *data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t*lengths, unsigned long data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const long *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const char *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const char *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const char *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
 
 
 /**
@@ -728,13 +728,13 @@ extern LIBLSL_C_API int32_t lsl_set_postprocessing(lsl_inlet in, uint32_t flags)
 * @return The capture time of the sample on the remote machine, or 0.0 if no new sample was available. 
 *         To remap this time stamp to the local clock, add the value returned by lsl_time_correction() to it. 
 */
-extern LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, int buffer_elements, double timeout, int *ec);
-extern LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, int32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
 
 /**
 * Pull a sample from the inlet and read it into an array of binary strings. These strings may contains 0's, therefore the lengths are read into
@@ -752,7 +752,7 @@ extern LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int3
 * @return The capture time of the sample on the remote machine, or 0.0 if no new sample was available. 
 *         To remap this time stamp to the local clock, add the value returned by lsl_time_correction() to it. 
 */
-extern LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *buffer_lengths, int32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *buffer_lengths, uint32_t buffer_elements, double timeout, int32_t *ec);
 
 /**
 * Pull a sample from the inlet and read it into a custom struct or buffer. 
@@ -790,13 +790,13 @@ extern LIBLSL_C_API double lsl_pull_sample_v(lsl_inlet in, void *buffer, int32_t
 *                 ec is *not* set to lsl_timeout_error (because this case is not considered an error condition).
 * @return data_elements_written Number of channel data elements written to the data buffer.
 */
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 
 /**
 * Pull a chunk of data from the inlet and read it into an array of binary strings. 
@@ -821,7 +821,7 @@ extern LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_b
 * @return data_elements_written Number of channel data elements written to the data buffer.
 */
 
-extern LIBLSL_C_API unsigned long lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, uint32_t *lengths_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, uint32_t *lengths_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 
 /**
 * Query whether samples are currently available for immediate pickup.

--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -509,9 +509,9 @@ extern LIBLSL_C_API int32_t lsl_push_sample_ftp(lsl_outlet out, const float *dat
 extern LIBLSL_C_API int32_t lsl_push_sample_d(lsl_outlet out, const double *data);
 extern LIBLSL_C_API int32_t lsl_push_sample_dt(lsl_outlet out, const double *data, double timestamp);
 extern LIBLSL_C_API int32_t lsl_push_sample_dtp(lsl_outlet out, const double *data, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_sample_l(lsl_outlet out, const long *data);
-extern LIBLSL_C_API int32_t lsl_push_sample_lt(lsl_outlet out, const long *data, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_sample_ltp(lsl_outlet out, const long *data, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_sample_l(lsl_outlet out, const int64_t *data);
+extern LIBLSL_C_API int32_t lsl_push_sample_lt(lsl_outlet out, const int64_t *data, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_sample_ltp(lsl_outlet out, const int64_t *data, double timestamp, int32_t pushthrough);
 extern LIBLSL_C_API int32_t lsl_push_sample_i(lsl_outlet out, const int32_t *data);
 extern LIBLSL_C_API int32_t lsl_push_sample_it(lsl_outlet out, const int32_t *data, double timestamp);
 extern LIBLSL_C_API int32_t lsl_push_sample_itp(lsl_outlet out, const int32_t *data, double timestamp, int32_t pushthrough);
@@ -557,11 +557,11 @@ extern LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data
 extern LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
 extern LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps);
 extern LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const long *data, uint32_t data_elements);
-extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps);
-extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const int64_t *data, uint32_t data_elements);
+extern LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const int64_t *data, uint32_t data_elements, double timestamp);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const int64_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const int64_t *data, uint32_t data_elements, const double *timestamps);
+extern LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const int64_t *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough);
 extern LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, uint32_t data_elements);
 extern LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp);
 extern LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough);
@@ -730,7 +730,7 @@ extern LIBLSL_C_API int32_t lsl_set_postprocessing(lsl_inlet in, uint32_t flags)
 */
 extern LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, int64_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, uint32_t buffer_elements, double timeout, int32_t *ec);
@@ -792,7 +792,7 @@ extern LIBLSL_C_API double lsl_pull_sample_v(lsl_inlet in, void *buffer, int32_t
 */
 extern LIBLSL_C_API uint32_t lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API uint32_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
-extern LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
+extern LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API uint32_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API uint32_t lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);
 extern LIBLSL_C_API uint32_t lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec);

--- a/LSL/liblsl/include/lsl_cpp.h
+++ b/LSL/liblsl/include/lsl_cpp.h
@@ -370,7 +370,7 @@ namespace lsl {
         */
         void push_sample(const std::vector<float> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_ftp(obj,(&data[0]),timestamp,pushthrough); }
         void push_sample(const std::vector<double> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_dtp(obj,(&data[0]),timestamp,pushthrough); }
-        void push_sample(const std::vector<long> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_ltp(obj,(&data[0]),timestamp,pushthrough); }
+        void push_sample(const std::vector<int64_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_ltp(obj,(&data[0]),timestamp,pushthrough); }
         void push_sample(const std::vector<int32_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_itp(obj,(&data[0]),timestamp,pushthrough); }
         void push_sample(const std::vector<int16_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_stp(obj,(&data[0]),timestamp,pushthrough); }
         void push_sample(const std::vector<char> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan(data.size()); lsl_push_sample_ctp(obj,(&data[0]),timestamp,pushthrough); }
@@ -387,7 +387,7 @@ namespace lsl {
         */
         void push_sample(const float *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_ftp(obj,(data),timestamp,pushthrough); }
         void push_sample(const double *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_dtp(obj,(data),timestamp,pushthrough); }
-        void push_sample(const long *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_ltp(obj,(data),timestamp,pushthrough); }
+        void push_sample(const int64_t *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_ltp(obj,(data),timestamp,pushthrough); }
         void push_sample(const int32_t *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_itp(obj,(data),timestamp,pushthrough); }
         void push_sample(const int16_t *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_stp(obj,(data),timestamp,pushthrough); }
         void push_sample(const char *data, double timestamp=0.0, bool pushthrough=true) { lsl_push_sample_ctp(obj,(data),timestamp,pushthrough); }
@@ -510,7 +510,7 @@ namespace lsl {
         */
         void push_chunk_multiplexed(const std::vector<float> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ftp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
         void push_chunk_multiplexed(const std::vector<double> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_dtp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<long> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ltp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int64_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ltp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
         void push_chunk_multiplexed(const std::vector<int32_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_itp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
         void push_chunk_multiplexed(const std::vector<int16_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_stp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
         void push_chunk_multiplexed(const std::vector<char> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ctp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
@@ -526,7 +526,7 @@ namespace lsl {
         */
         void push_chunk_multiplexed(const std::vector<float> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ftnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
         void push_chunk_multiplexed(const std::vector<double> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_dtnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<long> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ltnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int64_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ltnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
         void push_chunk_multiplexed(const std::vector<int32_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_itnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
         void push_chunk_multiplexed(const std::vector<int16_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_stnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
         void push_chunk_multiplexed(const std::vector<char> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ctnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
@@ -554,7 +554,7 @@ namespace lsl {
         */
         void push_chunk_multiplexed(const float *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ftp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
         void push_chunk_multiplexed(const double *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_dtp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const long *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ltp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const int64_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ltp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
         void push_chunk_multiplexed(const int32_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_itp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
         void push_chunk_multiplexed(const int16_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_stp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
         void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ctp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
@@ -581,7 +581,7 @@ namespace lsl {
         */
         void push_chunk_multiplexed(const float *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ftnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
         void push_chunk_multiplexed(const double *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_dtnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const long *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ltnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const int64_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ltnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
         void push_chunk_multiplexed(const int32_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_itnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
         void push_chunk_multiplexed(const int16_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_stnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
         void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ctnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
@@ -825,7 +825,7 @@ namespace lsl {
         */
         double pull_sample(std::vector<float> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
         double pull_sample(std::vector<double> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
-        double pull_sample(std::vector<long> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
+        double pull_sample(std::vector<int64_t> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
         double pull_sample(std::vector<int32_t> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
         double pull_sample(std::vector<int16_t> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
         double pull_sample(std::vector<char> &sample, double timeout=FOREVER) { sample.resize(channel_count); return pull_sample(&sample[0],(int32_t)sample.size(),timeout); }
@@ -843,7 +843,7 @@ namespace lsl {
         */
         double pull_sample(float *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_f(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
         double pull_sample(double *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_d(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
-        double pull_sample(long *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_l(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
+        double pull_sample(int64_t *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_l(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
         double pull_sample(int32_t *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_i(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
         double pull_sample(int16_t *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_s(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
         double pull_sample(char *buffer, int32_t buffer_elements, double timeout=FOREVER) { int32_t ec = 0; double res = lsl_pull_sample_c(obj,buffer,buffer_elements,timeout,&ec); check_error(ec); return res; }
@@ -963,7 +963,7 @@ namespace lsl {
         */
         std::size_t pull_chunk_multiplexed(float *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_f(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
         std::size_t pull_chunk_multiplexed(double *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_d(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(long *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_l(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(int64_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_l(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
         std::size_t pull_chunk_multiplexed(int32_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_i(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
         std::size_t pull_chunk_multiplexed(int16_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_s(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
         std::size_t pull_chunk_multiplexed(char *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_c(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }

--- a/LSL/liblsl/include/lsl_cpp.h
+++ b/LSL/liblsl/include/lsl_cpp.h
@@ -459,7 +459,7 @@ namespace lsl {
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
         template<class T> void push_chunk(const std::vector<T> &samples, const std::vector<double> &timestamps, bool pushthrough=true) {
-            for (unsigned k=0; k<samples.size()-1; k++)
+            for (std::size_t k=0; k<samples.size()-1; k++)
                 push_sample(samples[k],timestamps[k],false);
             if (!samples.empty())
                 push_sample(samples.back(),timestamps.back(),pushthrough);
@@ -494,7 +494,7 @@ namespace lsl {
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
         template<class T> void push_chunk_numeric_structs(const std::vector<T> &samples, const std::vector<double> &timestamps, bool pushthrough=true) {
-            for (unsigned k=0; k<samples.size()-1; k++)
+            for (std::size_t k=0; k<samples.size()-1; k++)
                 push_numeric_struct(samples[k],timestamps[k],false);
             if (!samples.empty())
                 push_numeric_struct(samples.back(),timestamps.back(),pushthrough);
@@ -508,13 +508,13 @@ namespace lsl {
         * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
-        void push_chunk_multiplexed(const std::vector<float> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ftp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<double> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_dtp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<long> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ltp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<int32_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_itp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<int16_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_stp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<char> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ctp(obj,(&buffer[0]),(unsigned long)buffer.size(),timestamp,pushthrough); }
-        void push_chunk_multiplexed(const std::vector<std::string> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) push_chunk_multiplexed(&buffer[0],(unsigned long)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<float> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ftp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<double> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_dtp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<long> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ltp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int32_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_itp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int16_t> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_stp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<char> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) lsl_push_chunk_ctp(obj,(&buffer[0]),(uint32_t)buffer.size(),timestamp,pushthrough); }
+        void push_chunk_multiplexed(const std::vector<std::string> &buffer, double timestamp=0.0, bool pushthrough=true) { if (!buffer.empty()) push_chunk_multiplexed(&buffer[0],(uint32_t)buffer.size(),timestamp,pushthrough); }
 
         /**
         * Push a chunk of multiplexed data into the outlet. One timestamp per sample is provided.
@@ -524,12 +524,12 @@ namespace lsl {
         * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
-        void push_chunk_multiplexed(const std::vector<float> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ftnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<double> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_dtnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<long> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ltnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<int32_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_itnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<int16_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_stnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
-        void push_chunk_multiplexed(const std::vector<char> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ctnp(obj,(&buffer[0]),(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<float> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ftnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<double> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_dtnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<long> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ltnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int32_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_itnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<int16_t> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_stnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
+        void push_chunk_multiplexed(const std::vector<char> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { if (!buffer.empty() && !timestamps.empty()) lsl_push_chunk_ctnp(obj,(&buffer[0]),(uint32_t)buffer.size(),(&timestamps[0]),pushthrough); }
         void push_chunk_multiplexed(const std::vector<std::string> &buffer, const std::vector<double> &timestamps, bool pushthrough=true) { 
             if (!buffer.empty()) { 
                 std::vector<uint32_t> lengths(buffer.size()); 
@@ -538,7 +538,7 @@ namespace lsl {
                     pointers[k] = buffer[k].c_str();
 				    lengths[k] = (uint32_t)buffer[k].size(); 
                 }
-                lsl_push_chunk_buftnp(obj,(&pointers[0]),&lengths[0],(unsigned long)buffer.size(),(&timestamps[0]),pushthrough); 
+                lsl_push_chunk_buftnp(obj,(&pointers[0]),&lengths[0],(uint32_t)buffer.size(),(&timestamps[0]),pushthrough);
             } 
         }
 
@@ -552,12 +552,12 @@ namespace lsl {
         * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
-        void push_chunk_multiplexed(const float *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ftp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const double *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_dtp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const long *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ltp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const int32_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_itp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const int16_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_stp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
-        void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ctp(obj,(buffer),(unsigned long)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const float *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ftp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const double *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_dtp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const long *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ltp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const int32_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_itp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const int16_t *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_stp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
+        void push_chunk_multiplexed(const char *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { lsl_push_chunk_ctp(obj,(buffer),(uint32_t)buffer_elements,timestamp,pushthrough); }
         void push_chunk_multiplexed(const std::string *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) { 
             if (buffer_elements) { 
                 std::vector<uint32_t> lengths(buffer_elements); 
@@ -566,7 +566,7 @@ namespace lsl {
                     pointers[k] = buffer[k].c_str();
 				    lengths[k] = (uint32_t)buffer[k].size(); 
                 }
-                lsl_push_chunk_buftp(obj,(&pointers[0]),&lengths[0],(unsigned long)buffer_elements,timestamp,pushthrough); 
+                lsl_push_chunk_buftp(obj,(&pointers[0]),&lengths[0],(uint32_t)buffer_elements,timestamp,pushthrough);
             } 
         }
 
@@ -579,12 +579,12 @@ namespace lsl {
         * @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
         *                    Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
         */
-        void push_chunk_multiplexed(const float *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ftnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const double *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_dtnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const long *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ltnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const int32_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_itnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const int16_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_stnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
-        void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ctnp(obj,(data_buffer),(unsigned long)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const float *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ftnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const double *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_dtnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const long *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ltnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const int32_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_itnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const int16_t *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_stnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
+        void push_chunk_multiplexed(const char *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { lsl_push_chunk_ctnp(obj,(data_buffer),(uint32_t)data_buffer_elements,(timestamp_buffer),pushthrough); }
         void push_chunk_multiplexed(const std::string *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) { 
             if (data_buffer_elements) { 
                 std::vector<uint32_t> lengths(data_buffer_elements); 
@@ -593,7 +593,7 @@ namespace lsl {
                     pointers[k] = data_buffer[k].c_str();
                     lengths[k] = (uint32_t)data_buffer[k].size(); 
                 }
-                lsl_push_chunk_buftnp(obj,(&pointers[0]),&lengths[0],(unsigned long)data_buffer_elements,(&timestamp_buffer[0]),pushthrough); 
+                lsl_push_chunk_buftnp(obj,(&pointers[0]),&lengths[0],(uint32_t)data_buffer_elements,(&timestamp_buffer[0]),pushthrough);
             } 
         }
 
@@ -961,18 +961,18 @@ namespace lsl {
         * @return data_elements_written Number of channel data elements written to the data buffer.
         * @throws lost_error (if the stream source has been lost).
         */
-        std::size_t pull_chunk_multiplexed(float *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_f(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(double *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_d(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(long *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_l(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(int32_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_i(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(int16_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_s(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
-        std::size_t pull_chunk_multiplexed(char *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_c(obj,data_buffer,timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(float *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_f(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(double *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_d(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(long *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_l(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(int32_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_i(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(int16_t *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_s(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
+        std::size_t pull_chunk_multiplexed(char *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) { int32_t ec=0; std::size_t res = lsl_pull_chunk_c(obj,data_buffer,timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec); check_error(ec); return res; }
         std::size_t pull_chunk_multiplexed(std::string *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) {
             int32_t ec = 0; 
             if (data_buffer_elements) {
                 std::vector<char*> result_strings(data_buffer_elements);
                 std::vector<uint32_t> result_lengths(data_buffer_elements); 
-                std::size_t num = lsl_pull_chunk_buf(obj,&result_strings[0],&result_lengths[0],timestamp_buffer,(unsigned long)data_buffer_elements,(unsigned long)timestamp_buffer_elements,timeout,&ec);
+                std::size_t num = lsl_pull_chunk_buf(obj,&result_strings[0],&result_lengths[0],timestamp_buffer,(uint32_t)data_buffer_elements,(uint32_t)timestamp_buffer_elements,timeout,&ec);
                 check_error(ec);
                 for (std::size_t k=0;k<num;k++) {
                     data_buffer[k].assign(result_strings[k],result_lengths[k]);

--- a/LSL/liblsl/src/legacy/legacy_abi.cpp
+++ b/LSL/liblsl/src/legacy/legacy_abi.cpp
@@ -101,14 +101,14 @@ stream_outlet::~stream_outlet() { delete impl_; }
 stream_info stream_outlet::info() const { return stream_info(&impl_->info()); }
 void stream_outlet::push_sample(const std::vector<float> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const std::vector<double> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
-void stream_outlet::push_sample(const std::vector<long> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
+void stream_outlet::push_sample(const std::vector<int64_t> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const std::vector<int> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const std::vector<short> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const std::vector<char> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const std::vector<std::string> &data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const float *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const double *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
-void stream_outlet::push_sample(const long *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
+void stream_outlet::push_sample(const int64_t *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const int *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const short *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
 void stream_outlet::push_sample(const char *data, double timestamp, bool pushthrough) { impl_->push_sample(data,timestamp,pushthrough); }
@@ -130,14 +130,14 @@ void stream_inlet::close_stream() { impl_->close_stream(); }
 double stream_inlet::time_correction(double timeout) { return impl_->time_correction(timeout); }
 double stream_inlet::pull_sample(std::vector<float> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(std::vector<double> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
-double stream_inlet::pull_sample(std::vector<long> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
+double stream_inlet::pull_sample(std::vector<int64_t> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(std::vector<int> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(std::vector<short> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(std::vector<char> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(std::vector<std::string> &sample, double timeout) { return impl_->pull_sample(sample,timeout); }
 double stream_inlet::pull_sample(float *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
 double stream_inlet::pull_sample(double *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
-double stream_inlet::pull_sample(long *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
+double stream_inlet::pull_sample(int64_t *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
 double stream_inlet::pull_sample(int *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
 double stream_inlet::pull_sample(short *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }
 double stream_inlet::pull_sample(char *buffer, int buffer_elements, double timeout) { return impl_->pull_sample(buffer,buffer_elements,timeout); }

--- a/LSL/liblsl/src/legacy/legacy_abi.h
+++ b/LSL/liblsl/src/legacy/legacy_abi.h
@@ -276,7 +276,7 @@ namespace lsl {
 		*/
 		void push_sample(const std::vector<float> &data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const std::vector<double> &data, double timestamp=0.0, bool pushthrough=true);
-		void push_sample(const std::vector<long> &data, double timestamp=0.0, bool pushthrough=true);
+		void push_sample(const std::vector<int64_t> &data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const std::vector<int> &data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const std::vector<short> &data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const std::vector<char> &data, double timestamp=0.0, bool pushthrough=true);
@@ -293,7 +293,7 @@ namespace lsl {
 		*/
 		void push_sample(const float *data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const double *data, double timestamp=0.0, bool pushthrough=true);
-		void push_sample(const long *data, double timestamp=0.0, bool pushthrough=true);
+		void push_sample(const int64_t *data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const int *data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const short *data, double timestamp=0.0, bool pushthrough=true);
 		void push_sample(const char *data, double timestamp=0.0, bool pushthrough=true);
@@ -539,7 +539,7 @@ namespace lsl {
 		*/
 		double pull_sample(std::vector<float> &sample, double timeout=FOREVER);
 		double pull_sample(std::vector<double> &sample, double timeout=FOREVER);
-		double pull_sample(std::vector<long> &sample, double timeout=FOREVER);
+		double pull_sample(std::vector<int64_t> &sample, double timeout=FOREVER);
 		double pull_sample(std::vector<int> &sample, double timeout=FOREVER);
 		double pull_sample(std::vector<short> &sample, double timeout=FOREVER);
 		double pull_sample(std::vector<char> &sample, double timeout=FOREVER);
@@ -557,7 +557,7 @@ namespace lsl {
 		*/
 		double pull_sample(float *buffer, int buffer_elements, double timeout=FOREVER);
 		double pull_sample(double *buffer, int buffer_elements, double timeout=FOREVER);
-		double pull_sample(long *buffer, int buffer_elements, double timeout=FOREVER);
+		double pull_sample(int64_t *buffer, int buffer_elements, double timeout=FOREVER);
 		double pull_sample(int *buffer, int buffer_elements, double timeout=FOREVER);
 		double pull_sample(short *buffer, int buffer_elements, double timeout=FOREVER);
 		double pull_sample(char *buffer, int buffer_elements, double timeout=FOREVER);

--- a/LSL/liblsl/src/lsl_inlet_c.cpp
+++ b/LSL/liblsl/src/lsl_inlet_c.cpp
@@ -202,31 +202,31 @@ LIBLSL_C_API int32_t lsl_set_postprocessing(lsl_inlet in, uint32_t flags) {
 *		  To remap this time stamp to the local clock, add the value returned by lsl_time_correction() to it. 
 * @param ec Error code: if nonzero, can be either lsl_timeout_error (if the timeout has expired) or lsl_lost_error (if the stream source has been lost).
 */
-LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_f(lsl_inlet in, float *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, int buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, short *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, short *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_c(lsl_inlet in, char *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 	if (ec)
 		*ec = lsl_no_error;
 	try {
@@ -272,7 +272,7 @@ LIBLSL_C_API double lsl_pull_sample_str(lsl_inlet in, char **buffer, int32_t buf
 	return 0.0;
 }
 
-LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *buffer_lengths, int32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_buf(lsl_inlet in, char **buffer, uint32_t *buffer_lengths, uint32_t buffer_elements, double timeout, int32_t *ec) {
 	if (ec)
 		*ec = lsl_no_error;
 	try {
@@ -359,38 +359,38 @@ LIBLSL_C_API double lsl_pull_sample_v(lsl_inlet in, void *buffer, int32_t buffer
 	return 0.0;
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_f(lsl_inlet in, float *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_i(lsl_inlet in, int *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_s(lsl_inlet in, short *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_s(lsl_inlet in, short *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_c(lsl_inlet in, char *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	if (ec)
 		*ec = lsl_no_error;
 	try {
 		// capture output in a temporary string buffer
 		if (data_buffer_elements) {
 			std::vector<std::string> tmp(data_buffer_elements);
-			unsigned long result = ((stream_inlet_impl*)in)->pull_chunk_multiplexed(&tmp[0],timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
+			uint32_t result = ((stream_inlet_impl*)in)->pull_chunk_multiplexed(&tmp[0],timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
 			// allocate memory and copy over into buffer
 			for (std::size_t k=0;k<tmp.size();k++) {
 				data_buffer[k] = (char*)malloc(tmp[k].size()+1);
@@ -430,14 +430,14 @@ LIBLSL_C_API unsigned long lsl_pull_chunk_str(lsl_inlet in, char **data_buffer, 
 	return 0;
 }
 
-LIBLSL_C_API unsigned long lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, unsigned *lengths_buffer, double *timestamp_buffer, unsigned long data_buffer_elements, unsigned long timestamp_buffer_elements, double timeout, int *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_buf(lsl_inlet in, char **data_buffer, uint32_t *lengths_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	if (ec)
 		*ec = lsl_no_error;
 	try {
 		// capture output in a temporary string buffer
 		if (data_buffer_elements) {
 			std::vector<std::string> tmp(data_buffer_elements);
-			unsigned long result = ((stream_inlet_impl*)in)->pull_chunk_multiplexed(&tmp[0],timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
+			uint32_t result = ((stream_inlet_impl*)in)->pull_chunk_multiplexed(&tmp[0],timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout);
 			// allocate memory and copy over into buffer
 			for (uint32_t k=0;k<tmp.size();k++) {
 				data_buffer[k] = (char*)malloc(tmp[k].size()+1);

--- a/LSL/liblsl/src/lsl_inlet_c.cpp
+++ b/LSL/liblsl/src/lsl_inlet_c.cpp
@@ -210,7 +210,7 @@ LIBLSL_C_API double lsl_pull_sample_d(lsl_inlet in, double *buffer, uint32_t buf
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, long *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_l(lsl_inlet in, int64_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
@@ -218,7 +218,7 @@ LIBLSL_C_API double lsl_pull_sample_i(lsl_inlet in, int32_t *buffer, uint32_t bu
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
-LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, short *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API double lsl_pull_sample_s(lsl_inlet in, int16_t *buffer, uint32_t buffer_elements, double timeout, int32_t *ec) {
 		return ((stream_inlet_impl*)in)->pull_sample_noexcept(buffer,buffer_elements,timeout,(lsl_error_code_t*) ec);
 }
 
@@ -367,7 +367,7 @@ LIBLSL_C_API uint32_t lsl_pull_chunk_d(lsl_inlet in, double *data_buffer, double
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, long *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_l(lsl_inlet in, int64_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
@@ -375,7 +375,7 @@ LIBLSL_C_API uint32_t lsl_pull_chunk_i(lsl_inlet in, int32_t *data_buffer, doubl
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 
-LIBLSL_C_API uint32_t lsl_pull_chunk_s(lsl_inlet in, short *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
+LIBLSL_C_API uint32_t lsl_pull_chunk_s(lsl_inlet in, int16_t *data_buffer, double *timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout, int32_t *ec) {
 	return ((stream_inlet_impl*)in)->pull_chunk_multiplexed_noexcept(data_buffer,timestamp_buffer,data_buffer_elements,timestamp_buffer_elements,timeout,(lsl_error_code_t*)ec);
 }
 

--- a/LSL/liblsl/src/lsl_outlet_c.cpp
+++ b/LSL/liblsl/src/lsl_outlet_c.cpp
@@ -200,138 +200,138 @@ LIBLSL_C_API int32_t lsl_push_sample_buftp(lsl_outlet out, const char **data, co
 	}
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_f(lsl_outlet out, const float *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_d(lsl_outlet out, const double *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const long *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_l(lsl_outlet out, const long *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_i(lsl_outlet out, const int32_t *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_s(lsl_outlet out, const int16_t *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const char *data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_c(lsl_outlet out, const char *data, uint32_t data_elements) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_ft(lsl_outlet out, const float *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_dt(lsl_outlet out, const double *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_lt(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_it(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_st(lsl_outlet out, const int16_t *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_ct(lsl_outlet out, const char *data, uint32_t data_elements, double timestamp) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ftp(lsl_outlet out, const float *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_dtp(lsl_outlet out, const double *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const long *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ltp(lsl_outlet out, const long *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_itp(lsl_outlet out, const int32_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_stp(lsl_outlet out, const int16_t *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ctp(lsl_outlet out, const char *data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data,data_elements, timestamp, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_ftn(lsl_outlet out, const float *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_dtn(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_ltn(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_itn(lsl_outlet out, const int32_t *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_stn(lsl_outlet out, const int16_t *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_ctn(lsl_outlet out, const char *data, uint32_t data_elements, const double *timestamps) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ftnp(lsl_outlet out, const float *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_dtnp(lsl_outlet out, const double *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const long *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ltnp(lsl_outlet out, const long *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_itnp(lsl_outlet out, const int32_t *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_stnp(lsl_outlet out, const int16_t *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_ctnp(lsl_outlet out, const char *data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	return ((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(data, timestamps, data_elements, pushthrough);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_str(lsl_outlet out, const char **data, uint32_t data_elements) {
 	return lsl_push_chunk_strtp(out, data, data_elements, 0.0, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_strt(lsl_outlet out, const char **data, uint32_t data_elements, double timestamp) {
 	return lsl_push_chunk_strtp(out, data, data_elements, timestamp, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	try {
 		std::vector<std::string> tmp;
-		for (unsigned long k=0;k<data_elements;k++)
+		for (uint32_t k=0;k<data_elements;k++)
 			tmp.push_back(std::string(data[k]));
 		if (data_elements)
 			((stream_outlet_impl*)out)->push_chunk_multiplexed(&tmp[0], tmp.size(), timestamp, pushthrough);
@@ -351,17 +351,17 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtp(lsl_outlet out, const char **data, uns
 	}
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_strtn(lsl_outlet out, const char **data, uint32_t data_elements, const double *timestamps) {
 	return lsl_push_chunk_strtnp(out, data, data_elements, timestamps, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
-			for (unsigned long k=0;k<data_elements;k++)
+			for (uint32_t k=0;k<data_elements;k++)
 				tmp.push_back(std::string(data[k]));
-			((stream_outlet_impl*)out)->push_chunk_multiplexed_noexcept(&tmp[0], timestamps, data_elements, pushthrough);
+			((stream_outlet_impl*)out)->push_chunk_multiplexed(&tmp[0], timestamps, tmp.size(), pushthrough);
 		}
 		return lsl_no_error;
 	} 
@@ -379,21 +379,21 @@ LIBLSL_C_API int32_t lsl_push_chunk_strtnp(lsl_outlet out, const char **data, un
 	}
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements) {
+LIBLSL_C_API int32_t lsl_push_chunk_buf(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements) {
 	return lsl_push_chunk_buftp(out, data, lengths, data_elements, 0.0, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp) {
+LIBLSL_C_API int32_t lsl_push_chunk_buft(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, double timestamp) {
 	return lsl_push_chunk_buftp(out, data, lengths, data_elements, timestamp, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, double timestamp, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, double timestamp, int32_t pushthrough) {
 	try {
 		std::vector<std::string> tmp;
-		for (unsigned long k=0;k<data_elements;k++)
+		for (uint32_t k=0;k<data_elements;k++)
 			tmp.push_back(std::string(data[k],lengths[k]));
 		if (data_elements)
-			((stream_outlet_impl*)out)->push_chunk_multiplexed(&tmp[0],tmp.size(),timestamp,pushthrough);
+			((stream_outlet_impl*)out)->push_chunk_multiplexed(&tmp[0], tmp.size(), timestamp, pushthrough);
 		return lsl_no_error;
 	} 
 	catch(std::range_error &e) {
@@ -410,15 +410,15 @@ LIBLSL_C_API int32_t lsl_push_chunk_buftp(lsl_outlet out, const char **data, con
 	}
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps) {
+LIBLSL_C_API int32_t lsl_push_chunk_buftn(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, const double *timestamps) {
 	return lsl_push_chunk_buftnp(out, data, lengths, data_elements, timestamps, true);
 }
 
-LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, unsigned long data_elements, const double *timestamps, int32_t pushthrough) {
+LIBLSL_C_API int32_t lsl_push_chunk_buftnp(lsl_outlet out, const char **data, const uint32_t *lengths, uint32_t data_elements, const double *timestamps, int32_t pushthrough) {
 	try {
 		if (data_elements) {
 			std::vector<std::string> tmp;
-			for (unsigned long k=0;k<data_elements;k++)
+			for (uint32_t k=0;k<data_elements;k++)
 				tmp.push_back(std::string(data[k],lengths[k]));
 			((stream_outlet_impl*)out)->push_chunk_multiplexed(&tmp[0],timestamps,(std::size_t)data_elements,pushthrough);
 		}

--- a/LSL/liblsl/src/stream_inlet_impl.h
+++ b/LSL/liblsl/src/stream_inlet_impl.h
@@ -70,7 +70,7 @@ namespace lsl {
 		*/
 		double pull_sample(std::vector<float> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
 		double pull_sample(std::vector<double> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
-		double pull_sample(std::vector<long> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<int64_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
 		double pull_sample(std::vector<int32_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
 		double pull_sample(std::vector<int16_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
 		double pull_sample(std::vector<char> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
@@ -89,7 +89,7 @@ namespace lsl {
 		*/
 		double pull_sample(float *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
 		double pull_sample(double *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(long *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(int64_t *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
 		double pull_sample(int32_t *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
 		double pull_sample(int16_t *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
 		double pull_sample(char *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }

--- a/LSL/liblsl/src/stream_inlet_impl.h
+++ b/LSL/liblsl/src/stream_inlet_impl.h
@@ -68,13 +68,13 @@ namespace lsl {
 		*		   To remap this time stamp to the local clock, add the value returned by .time_correction() to it.
 		*		   This is only necessary if the clocks of the source and destination machine are not synchronized to high enough precision.
 		*/
-		double pull_sample(std::vector<float> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<double> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<long> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<int32_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<int16_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<char> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
-		double pull_sample(std::vector<std::string> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(int32_t)data.size(),timeout); }
+		double pull_sample(std::vector<float> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<double> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<long> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<int32_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<int16_t> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<char> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
+		double pull_sample(std::vector<std::string> &data, double timeout=FOREVER) { data.resize(conn_.type_info().channel_count()); return pull_sample(&data[0],(uint32_t)data.size(),timeout); }
 
 		/**
 		* Pull a sample from the inlet and read it into a pointer to values.
@@ -87,16 +87,16 @@ namespace lsl {
 		*		   To remap this time stamp to the local clock, add the value returned by .time_correction() to it.
 		*		   This is only necessary if the clocks of the source and destination machine are not synchronized to high enough precision.
 		*/
-		double pull_sample(float *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(double *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(long *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(int32_t *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(int16_t *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(char *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
-		double pull_sample(std::string *buffer, int32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(float *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(double *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(long *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(int32_t *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(int16_t *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(char *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
+		double pull_sample(std::string *buffer, uint32_t buffer_elements, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_typed(buffer,buffer_elements,timeout)); }
 
 		template<typename T>
-		double pull_sample_noexcept(T* buffer, int32_t buffer_elements, double timeout=FOREVER, lsl_error_code_t* ec=NULL) BOOST_NOEXCEPT {
+		double pull_sample_noexcept(T* buffer, uint32_t buffer_elements, double timeout=FOREVER, lsl_error_code_t* ec=NULL) BOOST_NOEXCEPT {
 			lsl_error_code_t dummy;
 			if (!ec) ec = &dummy;
 			*ec = lsl_no_error;
@@ -124,7 +124,7 @@ namespace lsl {
 		*		   To remap this time stamp to the local clock, add the value returned by .time_correction() to it.
 		*		   This is only necessary if the clocks of the source and destination machine are not synchronized to high enough precision.
 		*/
-		double pull_numeric_raw(void *sample, int32_t buffer_bytes, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_untyped(sample,buffer_bytes,timeout)); }
+		double pull_numeric_raw(void *sample, uint32_t buffer_bytes, double timeout=FOREVER) { return postprocess(data_receiver_.pull_sample_untyped(sample,buffer_bytes,timeout)); }
 
 		/**
 		* Pull a chunk of data from the inlet.
@@ -142,8 +142,9 @@ namespace lsl {
 		* @return data_elements_written Number of channel data elements written to the data buffer.
 		* @throws lost_error (if the stream source has been lost).
 		*/
-		template<class T> std::size_t pull_chunk_multiplexed(T *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0) {
-			std::size_t samples_written=0, num_chans = info().channel_count(), max_samples = data_buffer_elements/num_chans;
+		template <class T>
+		uint32_t pull_chunk_multiplexed(T* data_buffer, double* timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout = 0.0) {
+			uint32_t samples_written=0, num_chans = info().channel_count(), max_samples = data_buffer_elements/num_chans;
 			if (data_buffer_elements % num_chans != 0)
 				throw std::runtime_error("The number of buffer elements must be a multiple of the stream's channel count.");
 			if (timestamp_buffer && max_samples != timestamp_buffer_elements)
@@ -159,7 +160,8 @@ namespace lsl {
 			return samples_written*num_chans;
 		}
 
-		template<class T> std::size_t pull_chunk_multiplexed_noexcept(T *data_buffer, double *timestamp_buffer, std::size_t data_buffer_elements, std::size_t timestamp_buffer_elements, double timeout=0.0, lsl_error_code_t* ec=NULL) BOOST_NOEXCEPT {
+		template <class T>
+		uint32_t pull_chunk_multiplexed_noexcept(T* data_buffer, double* timestamp_buffer, uint32_t data_buffer_elements, uint32_t timestamp_buffer_elements, double timeout = 0.0, lsl_error_code_t* ec = NULL) BOOST_NOEXCEPT {
 			lsl_error_code_t dummy;
 			if(!ec) ec = &dummy;
 			*ec = lsl_no_error;

--- a/LSL/liblsl/src/stream_outlet_impl.h
+++ b/LSL/liblsl/src/stream_outlet_impl.h
@@ -54,7 +54,7 @@ namespace lsl {
 		*/
 		void push_sample(const std::vector<float> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
 		void push_sample(const std::vector<double> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
-		void push_sample(const std::vector<long> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
+		void push_sample(const std::vector<int64_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
 		void push_sample(const std::vector<int32_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
 		void push_sample(const std::vector<int16_t> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
 		void push_sample(const std::vector<char> &data, double timestamp=0.0, bool pushthrough=true) { check_numchan((int32_t)data.size()); enqueue(&data[0],timestamp,pushthrough); }
@@ -70,7 +70,7 @@ namespace lsl {
 		*/
 		void push_sample(const float *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 		void push_sample(const double *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
-		void push_sample(const long *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
+		void push_sample(const int64_t *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 		void push_sample(const int32_t *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 		void push_sample(const int16_t *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }
 		void push_sample(const char *data, double timestamp=0.0, bool pushthrough=true) { enqueue(data,timestamp,pushthrough); }

--- a/LSL/liblsl/src/stream_outlet_impl.h
+++ b/LSL/liblsl/src/stream_outlet_impl.h
@@ -123,15 +123,15 @@ namespace lsl {
 		* @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
 		*					 Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
 		*/
-		template<class T> void push_chunk_multiplexed(const T *data_buffer, const double *timestamp_buffer, std::size_t data_buffer_elements, bool pushthrough=true) {
-			std::size_t num_chans = info().channel_count(), num_samples = data_buffer_elements/num_chans;
+		template<class T> void push_chunk_multiplexed(const T *data_buffer, const double *timestamp_buffer, uint32_t data_buffer_elements, bool pushthrough=true) {
+			uint32_t num_chans = info().channel_count(), num_samples = data_buffer_elements/num_chans;
 			if (data_buffer_elements % num_chans != 0)
 				throw std::runtime_error("The number of buffer elements to send is not a multiple of the stream's channel count.");
 			if (!data_buffer)
 				throw std::runtime_error("The data buffer pointer must not be NULL.");
 			if (!timestamp_buffer)
 				throw std::runtime_error("The timestamp buffer pointer must not be NULL.");
-			for (std::size_t k=0; k<num_samples; k++)
+			for (uint32_t k=0; k<num_samples; k++)
 				enqueue(&data_buffer[k*num_chans],timestamp_buffer[k],pushthrough && k==num_samples-1);
 		}
 
@@ -164,8 +164,8 @@ namespace lsl {
 		* @param pushthrough Whether to push the chunk through to the receivers instead of buffering it with subsequent samples.
 		*					 Note that the chunk_size, if specified at outlet construction, takes precedence over the pushthrough flag.
 		*/
-		template<class T> void push_chunk_multiplexed(const T *buffer, std::size_t buffer_elements, double timestamp=0.0, bool pushthrough=true) {
-			std::size_t num_chans = info().channel_count(), num_samples = buffer_elements/num_chans;
+		template<class T> void push_chunk_multiplexed(const T *buffer, uint32_t buffer_elements, double timestamp=0.0, bool pushthrough=true) {
+			uint32_t num_chans = info().channel_count(), num_samples = buffer_elements/num_chans;
 			if (buffer_elements % num_chans != 0)
 				throw std::runtime_error("The number of buffer elements to send is not a multiple of the stream's channel count.");
 			if (!buffer)
@@ -176,7 +176,7 @@ namespace lsl {
 				if (info().nominal_srate() != IRREGULAR_RATE)
 					timestamp = timestamp - (num_samples-1)/info().nominal_srate();
 				push_sample(buffer,timestamp,pushthrough && (num_samples==1));
-				for (std::size_t k=1; k<num_samples; k++)
+				for (uint32_t k=1; k<num_samples; k++)
 					push_sample(&buffer[k*num_chans],DEDUCED_TIMESTAMP,pushthrough && (k==num_samples-1));
 			}
 		}


### PR DESCRIPTION
See #165 for the extended discussion.

In short: the API/ABI uses integer types (short, long, etc.) that have different sizes on different platforms.