### PR TITLE
Expose streaminfo::matches_query to C API

### DIFF
--- a/LSL/liblsl/include/lsl_c.h
+++ b/LSL/liblsl/include/lsl_c.h
@@ -449,6 +449,19 @@ extern LIBLSL_C_API int32_t lsl_get_channel_bytes(lsl_streaminfo info);
 /// Number of bytes occupied by a sample (0 for string-typed channels).
 extern LIBLSL_C_API int32_t lsl_get_sample_bytes(lsl_streaminfo info);
 
+/**
+ * Tries to match the stream info XML element @p info against an
+ * <a href="https://en.wikipedia.org/wiki/XPath#Syntax_and_semantics_(XPath_1.0)">XPath</a> query.
+ *
+ * Example query strings:
+ * @code
+ * channel_count>5 and type='EEG'
+ * type='TestStream' or contains(name,'Brain')
+ * name='ExampleStream'
+ * @endcode
+ */
+extern LIBLSL_C_API int lsl_stream_info_matches_query(lsl_streaminfo info, const char* query);
+
 /// Create a streaminfo object from an XML representation
 extern LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(const char *xml);
 

--- a/LSL/liblsl/include/lsl_cpp.h
+++ b/LSL/liblsl/include/lsl_cpp.h
@@ -265,6 +265,11 @@ namespace lsl {
         */
 		xml_element desc();
 
+		/** @copydoc lsl_stream_info_matches_query */
+		bool matches_query(const char* query) const {
+			return lsl_stream_info_matches_query(obj, query);
+		}
+
 
         // ===============================
         // === Miscellaneous Functions ===

--- a/LSL/liblsl/src/lsl_streaminfo_c.cpp
+++ b/LSL/liblsl/src/lsl_streaminfo_c.cpp
@@ -65,6 +65,10 @@ LIBLSL_C_API char *lsl_get_xml(lsl_streaminfo info) {
 LIBLSL_C_API int lsl_get_channel_bytes(lsl_streaminfo info) { return ((stream_info_impl*)info)->channel_bytes(); }
 LIBLSL_C_API int lsl_get_sample_bytes(lsl_streaminfo info) { return ((stream_info_impl*)info)->sample_bytes(); }
 
+LIBLSL_C_API int lsl_stream_info_matches_query(lsl_streaminfo info, const char* query) {
+	return ((stream_info_impl*)info)->matches_query(query);
+}
+
 LIBLSL_C_API lsl_streaminfo lsl_streaminfo_from_xml(const char *xml) {
 	try {
 		stream_info_impl *impl = new stream_info_impl(); 


### PR DESCRIPTION
For some LabRecorder functionality checking if a stream matches a query after resolving the stream is necessary, so instead of bundling yet another XML library this PR exposes the existing function in the C API.