### PR TITLE
Adding submodule for Trigno Wireless and Tobii Pro Nano

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -152,3 +152,9 @@
 [submodule "Apps/Qualisys"]
 	path = Apps/Qualisys
 	url = https://github.com/qualisys/qualisys_lsl_app.git
+[submodule "Apps/TrignoWireless"]
+	path = Apps/QuaTrignoWirelesslisys
+	url = https://github.com/haze-sama/TrignoWireless.git
+[submodule "Apps/TobiiProNano"]
+	path = Apps/TobiiProNano
+	url = https://github.com/haze-sama/TobiiProNano.git


### PR DESCRIPTION
Hi,

I have worked during the last few months on two sublibraries for EMG and Eye-Tracker and I would like to share my work.
I tested it on Windows, Linux and OSX.

Note: Currently, Eye-Tracker drivers are only provided for Windows and Mac.