### PR TITLE
Added Link to EyeTechDS VT3-Mini

### DIFF
--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -92,6 +92,7 @@ Several eye tracking systems are currently supported by LSL and included in the 
   * `HTC Vive Eye <https://github.com/mit-ll/Signal-Acquisition-Modules-for-Lab-Streaming-Layer>`__
   * Custom 2-camera eye trackers (with some hacking)
   * :lslrepo:`Pupil-Labs <PupilLabs>`
+  * :lslrepo:`EyeTechDS - VT3-Mini <EyeTechDS>`
 
 Supported Human Interface Hardware
 **********************************


### PR DESCRIPTION
Added a link to the EyeTechDS VT3-Mini App that was developed by Intheon
The following was added line 95 (under PupilLabs
* :lslrepo:`EyeTechDS - VT3-Mini <EyeTechDS>`