### PR TITLE
enh - add Artinis NIRS devices to supported_devices.rst

### DIFF
--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -74,15 +74,10 @@ The following systems are also supported by a separate program, the :doc:`OpenVi
 Supported fNIRS Hardware
 ************************
 The following devices support LSL natively without any additional software:
-  * `NIRx NIRScout <https://nirx.net/nirscout>`__ and NIRSport 2 <https://nirx.net/nirsport>`__ via `Aurora <https://nirx.net/software>`__ and `Turbo-Satori <https://nirx.net/turbosatori>`__
+  * `NIRx NIRScout <https://nirx.net/nirscout>`__ and `NIRSport 2 <https://nirx.net/nirsport>`__ via `Aurora <https://nirx.net/software>`__ and `Turbo-Satori <https://nirx.net/turbosatori>`__
   * `GowerLabs LUMO <https://www.gowerlabs.co.uk/lumo>`__
   * `Cortivision PHOTON CAP <https://www.cortivision.com/products/photon/>`__
-  * `Artinis Brite <https://www.artinis.com/Brite-family>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
-  * `Artinis Portalite <https://www.artinis.com/portalite-mkii>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
-  * `Artinis PortaMon <https://www.artinis.com/PortaMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
-  * `Artinis OxyMon <https://www.artinis.com/OxyMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
-  * `Artinis OctaMon <https://www.artinis.com/OctaMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
-  * `Artinis NIRS-EEG package <https://www.artinis.com/nirs-eeg-package>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis Brite Family <https://www.artinis.com/Brite-family>`__,  `Portalite <https://www.artinis.com/portalite-mkii>`__  `PortaMon <https://www.artinis.com/PortaMon>`__, `OxyMon <https://www.artinis.com/OxyMon>`__, `OctaMon <https://www.artinis.com/OctaMon>`__ and `Artinis NIRS-EEG package <https://www.artinis.com/nirs-eeg-package>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
 
 Supported Electrophysiological Hardware
 ****************************************

--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -80,6 +80,12 @@ The following devices support LSL natively without any additional software:
   * `NIRx NIRSport 2 <https://nirx.net/nirsport>`__  via `Aurora <https://nirx.net/software>`__ and `Turbo-Satori <https://nirx.net/turbosatori>`__
   * `GowerLabs LUMO <https://www.gowerlabs.co.uk/lumo>`__
   * `Cortivision PHOTON CAP <https://www.cortivision.com/products/photon/>`__
+  * `Artinis Brite <https://www.artinis.com/Brite-family>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis Portalite <https://www.artinis.com/portalite-mkii>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis PortaMon <https://www.artinis.com/PortaMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis OxyMon <https://www.artinis.com/OxyMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis OctaMon <https://www.artinis.com/OctaMon>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
+  * `Artinis NIRS-EEG package <https://www.artinis.com/nirs-eeg-package>`__  via `OxySoft <https://www.artinis.com/OxySoft>`__
 
 Supported Electrophysiological Hardware
 ****************************************


### PR DESCRIPTION
Hi,

We'd like to add our devices to the list of supported NIRS devices. In fact, we support LSL for a couple of years already. Example publications: 
 - https://www.sciencedirect.com/science/article/pii/S1053811923000290
 - https://www.frontiersin.org/articles/10.3389/fnhum.2020.609096/full
 - https://www.frontiersin.org/articles/10.3389/fphys.2023.1124268/abstract
(and many more) 

A tutorial video can be found here:
https://www.youtube.com/watch?v=qgxrcykkve0&feature=youtu.be

Blog post about syncing, which includes LSL:
https://www.artinis.com/blogpost-all/2023/multimodal-fnirs-eeg-measurements-staying-in-sync

Link to our software: 
https://www.artinis.com/oxysoft/


If I missed any place where devices or software should be added, let me know. And if I made a mistake anywhere, please also let me know.

