### PR TITLE
Add HR bands to supported_devices.rst

### DIFF
--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -52,6 +52,7 @@ The following are some of the devices we know about that support LSL natively th
   * `Bittium Faros <https://www.bittium.com/medical/cardiology>`__      
       * `Faros Streamer <https://github.com/bwrc/faros-streamer>`__
       * `Faros Streamer 2 <https://github.com/bwrc/faros-streamer-2>`__
+  * `Heart Rate bands <https://github.com/abcsds/HRBand-LSL>`__ (Many bluetooth HR bands such as the Polar H10)
 
 
 The following devices support LSL natively without any additional software:


### PR DESCRIPTION
I'm supporting measurements with bluetooth HR bands. I added them to the `supported_devices' list as a third party software. I hope this is useful!