### PR TITLE
add Building LSL Apps to documentation index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ LabStreamingLayer's Documentation
 
    dev/doc_syntax
    dev/dev_guide
+   dev/app_build
    dev/app_dev
    dev/build_android
    dev/lib_dev


### PR DESCRIPTION
I was trying to build LabRecorder and I noticed the instructions were missing from the general index