### PR TITLE
docs: add RRStreamer (Android client) to supported HR devices (Heart rate bands)

### DIFF
--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -92,6 +92,7 @@ Various devices with ECG and/or EMG sensors are supported. Some of these have no
   * `bitalino (using LSL for Python) <https://github.com/fsuarezj/bitalino_lsl>`__ (wearables and various sensors)
   * `CGX (Cognionics) AIM Physiological Monitor <https://www.cgxsystems.com/auxiliary-input-module-gen2>`__ (ExG/Respiration/GSR/SPo2/Temp)
   * `Heart Rate Service bands <https://github.com/abcsds/HRBand-LSL>`__ (Many bluetooth HR bands such as the Polar H10)  
+  * `RRStreamer (Android) <https://github.com/abcsds/RRStreamer>`__ (BLE Heart Rate bands such as the Polar H10, streamed from an Android phone with R-R intervals in milliseconds)
   * `Polar H10 ECG <https://github.com/markspan/PolarBLE?tab=readme-ov-file>`__  
   * `Shimmer Examples (using LSL for C#) <https://github.com/ShimmerEngineering/liblsl-Csharp/tree/shimmer_dev/examples/SendData>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)
   * `Shimmer Examples (using LSL for Java) <https://github.com/ShimmerEngineering/liblsl-Java/tree/shimmer_dev/src/examples>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)  


### PR DESCRIPTION
Hi this is similar work to the HRBand-LSL, and this commit adds a sibling entry for the Android client at https://github.com/abcsds/RRStreamer — same BLE Heart Rate Service (0x180D) coverage, streamed from an Android phone with HR, and R-R or P-P intervals in milliseconds. This android bridge works for both HR-bands and PPG devices like the Polar Sense.