### PR TITLE
Update outdated links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ See the `liblsl repo <https://github.com/sccn/liblsl>`_ for more info.
   including Python and Matlab.
 
   * Python users need to ``pip install pylsl`` then try some of the
-    `provided examples <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples>`_.
+    `provided examples <https://github.com/labstreaminglayer/pylsl/tree/main/src/pylsl/examples>`_.
   * The `Matlab interface <https://github.com/labstreaminglayer/liblsl-Matlab/>`_
     is also popular but requires a little more work to get started;
     please see its README for more info.

--- a/docs/dev/app_dev.rst
+++ b/docs/dev/app_dev.rst
@@ -77,7 +77,7 @@ Python apps
 Python is another great language for app development, as long as your target audience has Python and the required libraries installed.
 You (and other app users) will need to have ``pylsl`` installed. The recommended way to get it is with ``pip install pylsl``.
 
-While there are no full application templates, look at the `example code <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples>`__ to begin.
+While there are no full application templates, look at the `example code <https://github.com/labstreaminglayer/pylsl/tree/main/src/pylsl/examples>`__ to begin.
 
 A couple good ``pylsl`` example apps are the one from :lslrepo:`PupilLabs`,
 which has both a plugin and a simple application, and :lslrepo:`SigVisualizer`.
@@ -86,5 +86,5 @@ which has both a plugin and a simple application, and :lslrepo:`SigVisualizer`.
 Windows Users
 -------------
 
-If users of applications linked to liblsl are encountering errors related to not being able to load the DLL, in particular missing a VCRUNTIME140_1.dll (or similar), then they probably need to install the `latest Microsoft Visual C++ Redistributable <https://support.microsoft.com/en-ca/help/2977003/the-latest-supported-visual-c-downloads>`__ for the application architecture
+If users of applications linked to liblsl are encountering errors related to not being able to load the DLL, in particular missing a VCRUNTIME140_1.dll (or similar), then they probably need to install the `latest Microsoft Visual C++ Redistributable <https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist>`__ for the application architecture
 

--- a/docs/dev/build_env.rst
+++ b/docs/dev/build_env.rst
@@ -43,7 +43,7 @@ Common Requirements
 .. _Qt:
 
 
-`Qt <http://qt.io>`__
+`Qt <https://www.qt.io/>`__
 `````````````````````
 
 For compatibility with Ubuntu 22.04 (20.04 with a PPA), Qt 6.2 is the oldest supported
@@ -61,7 +61,7 @@ configuration to the cmake parameters
 
 .. _boost:
 
-`Boost <https://boost.org>`__
+`Boost <https://www.boost.org/>`__
 `````````````````````````````
 
 Nowadays, Boost is mostly used for apps connecting to a device over the local network

--- a/docs/dev/build_full_tree.rst
+++ b/docs/dev/build_full_tree.rst
@@ -16,7 +16,7 @@ This main `labstreaminglayer repository <https://github.com/sccn/labstreaminglay
 contains only the general project structure and references (“`git
 submodules <https://git-scm.com/book/en/v2/Git-Tools-Submodules>`__”) to
 the liblsl C/C++ library
-(`LSL/liblsl <https://github.com/labstreaminglayer/liblsl/>`__),
+(`LSL/liblsl <https://github.com/sccn/liblsl/>`__),
 various language bindings (e.g.
 `LSL/liblsl-Python <https://github.com/labstreaminglayer/liblsl-Python>`__),
 the Apps to stream data from several types of devices

--- a/docs/dev/doc_syntax.rst
+++ b/docs/dev/doc_syntax.rst
@@ -24,7 +24,7 @@ Building the documentation
 The
 `documentation on ReadTheDocs <https://labstreaminglayer.readthedocs.io/>`_
 is built on every commit to the
-:repo:`Labstreaminglayer repository <labstreaminglayer/labstreaminglayer>`.
+:repo:`Labstreaminglayer repository <sccn/labstreaminglayer>`.
 In order to avoid several commits until you get the formatting right, install
 the Python ``sphinx`` package (either with pip or conda) and build the
 documentation with

--- a/docs/dev/examples.rst
+++ b/docs/dev/examples.rst
@@ -17,10 +17,10 @@ API Documentation
 *****************
 
 It is recommended that you clone the repository to get the respective code. The documentation is at the following locations:
-  * C: `C header file <https://github.com/sccn/liblsl/blob/master/include/lsl_c.h>`__
-  * C++: `C++ header file <https://github.com/sccn/liblsl/blob/master/include/lsl_cpp.h>`__,
+  * C: `C header file <https://github.com/sccn/liblsl/blob/main/include/lsl_c.h>`__
+  * C++: `C++ header file <https://github.com/sccn/liblsl/blob/main/include/lsl_cpp.h>`__,
     :doc:`in progress API documentation <liblsl:index>`
-  * Python: `pylsl module <https://github.com/labstreaminglayer/liblsl-Python/blob/master/pylsl/pylsl.py>`__
+  * Python: `pylsl module <https://github.com/labstreaminglayer/pylsl>`__
   * Java: `JavaDocs <https://github.com/labstreaminglayer/liblsl-Java/blob/master/javadoc/index.html>`__
   * C#: `LSL module <https://github.com/labstreaminglayer/liblsl-Csharp/blob/master/LSL.cs>`__
   * MATLAB: `class files <https://github.com/labstreaminglayer/liblsl-Matlab>`__.
@@ -35,67 +35,67 @@ C Example Programs: Basic to Advanced
 *************************************
 
 These two example programs illustrate the bread-and-butter use of LSL as it is executing in almost any device module that comes with the distribution:
-  * `Sending a multi-channel time series into LSL. <https://github.com/sccn/liblsl/blob/master/examples/SendDataC.c>`__
-  * `Receiving a multi-channel time series from LSL. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveDataC.c>`__
+  * `Sending a multi-channel time series into LSL. <https://github.com/sccn/liblsl/blob/main/examples/SendDataC.c>`__
+  * `Receiving a multi-channel time series from LSL. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveDataC.c>`__
 
 These two example programs illustrate a more special-purpose use case, namely sending arbitrary string-formatted data at irregular sampling rate. Such streams are used by programs that produce event markers, for example:
-  * `Sending a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/master/examples/SendStringMarkersC.c>`__
-  * `Receiving a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveStringMarkersC.c>`__
+  * `Sending a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/main/examples/SendStringMarkersC.c>`__
+  * `Receiving a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveStringMarkersC.c>`__
 
 The last example shows how to attach properly formatted meta-data to a stream, and how to read it out again at the receiving end. While meta-data is strictly optional, it is very useful to make streams self-describing. LSL has adopted the convention to name meta-data fields according to the XDF file format specification whenever the content type matches (for example EEG, Gaze, MoCap, VideoRaw, etc); the spec is `here <https://github.com/sccn/xdf/wiki/Meta-Data>`__. Note that some older example programs (SendData/ReceiveData) predate this convention and name the channels inconsistently.
-  * `Handling stream meta-data. <https://github.com/sccn/liblsl/blob/master/examples/HandleMetaDataC.c>`__
+  * `Handling stream meta-data. <https://github.com/sccn/liblsl/blob/main/examples/HandleMetaDataC.c>`__
 
 C++ Example Programs: Basic to Advanced
 ***************************************
 
 These two example programs illustrate the shortest amount of code that is necessary to get a C++ program linked to LSL:
-  * `Minimal data sending example. <https://github.com/sccn/liblsl/blob/master/examples/SendDataSimple.cpp>`__
-  * `Minimal data receiving example. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveDataSimple.cpp>`__
+  * `Minimal data sending example. <https://github.com/sccn/liblsl/blob/main/examples/SendDataSimple.cpp>`__
+  * `Minimal data receiving example. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveDataSimple.cpp>`__
 
 These two example programs demonstrate how to write more complete LSL clients in C++ (they are 1:1 equivalents of the corresponding C programs):
-  * `Sending a multi-channel time series into LSL. <https://github.com/sccn/liblsl/blob/master/examples/SendData.cpp>`__
-  * `Receiving a multi-channel time series from LSL. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveData.cpp>`__
+  * `Sending a multi-channel time series into LSL. <https://github.com/sccn/liblsl/blob/main/examples/SendData.cpp>`__
+  * `Receiving a multi-channel time series from LSL. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveData.cpp>`__
 
 These two programs transmit their data at the granularity of chunks instead of samples. This is mostly a convenience matter, since inlets and outlets can be configured to automatically batch samples into chunks for transmission. Note that for LSL the data is always a linear sequence of samples and data that is pushed as samples can be pulled out as chunks or vice versa. They also show how structs can be used to represent the sample data, instead of numeric arrays (which is mostly a syntactic difference):
-  * `Sending a multi-channel time series at chunk granularity. <https://github.com/sccn/liblsl/blob/master/examples/SendDataInChunks.cpp>`__
-  * `Receiving a multi-channel time series at chunk granularity. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveDataInChunks.cpp>`__
+  * `Sending a multi-channel time series at chunk granularity. <https://github.com/sccn/liblsl/blob/main/examples/SendDataInChunks.cpp>`__
+  * `Receiving a multi-channel time series at chunk granularity. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveDataInChunks.cpp>`__
 
 These two example programs illustrate a more special-purpose use case, namely sending arbitrary string-formatted data at irregular sampling rate. Such streams are used by programs that produce event markers, for example. These are 1:1 equivalents of the corresponding C programs:
-  * `Sending a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/master/examples/SendStringMarkers.cpp>`__
-  * `Receiving a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/master/examples/ReceiveStringMarkers.cpp>`__
+  * `Sending a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/main/examples/SendStringMarkers.cpp>`__
+  * `Receiving a stream of strings with irregular timing. <https://github.com/sccn/liblsl/blob/main/examples/ReceiveStringMarkers.cpp>`__
 
 The last example shows how to attach properly formatted meta-data to a stream, and how to read it out again at the receiving end. While meta-data is strictly optional, it is very useful to make streams self-describing. LSL has adopted the convention to name meta-data fields according to the XDF file format specification whenever the content type matches (for example EEG, Gaze, MoCap, VideoRaw, etc); the spec is `here <https://github.com/sccn/xdf/wiki/Meta-Data>`__. Note that some older example programs (SendData/ReceiveData) predate this convention and name the channels inconsistently.
-  * `Handling stream meta-data. <https://github.com/sccn/liblsl/blob/master/examples/HandleMetaData.cpp>`__
+  * `Handling stream meta-data. <https://github.com/sccn/liblsl/blob/main/examples/HandleMetaData.cpp>`__
 
 C/C++ Special-Purpose Example Programs
 **************************************
 These programs illustrate some special use cases of LSL that are also relevant for C programmers. See the lsl\_c.h header for the corresponding C APIs (they are very similar to the C++ code shown here).
 
 This example illustrates in more detail how streams can be resolved on the network:
-  * `Resolving all streams on the lab network, one-shot and continuous. <https://github.com/sccn/liblsl/blob/master/examples/GetAllStreams.cpp>`__
+  * `Resolving all streams on the lab network, one-shot and continuous. <https://github.com/sccn/liblsl/blob/main/examples/GetAllStreams.cpp>`__
 
 This example shows how to query the full XML meta-data of a stream (which may be several megabytes large):
-  * `Retrieving the XML meta-data of a stream. <https://github.com/sccn/liblsl/blob/master/examples/GetFullinfo.cpp>`__
+  * `Retrieving the XML meta-data of a stream. <https://github.com/sccn/liblsl/blob/main/examples/GetFullinfo.cpp>`__
 
 This example shows how to obtain time-correction values for a given stream. These time-correction values are offsets (in seconds) that are used to remap any stream's timestamps into the own local clock domain (just by adding the offset to the timestamp):
-  * `Querying the time-correction information for a stream. <https://github.com/sccn/liblsl/blob/master/examples/GetTimeCorrection.cpp>`__
+  * `Querying the time-correction information for a stream. <https://github.com/sccn/liblsl/blob/main/examples/GetTimeCorrection.cpp>`__
 
 Python Example Programs: Basic to Advanced
 ******************************************
 These examples show how to transmit a numeric multi-channel time series through LSL:
-  * `Sending a multi-channel time series into LSL. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/SendData.py>`__
-  * `Receiving a multi-channel time series from LSL. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/ReceiveData.py>`__
+  * `Sending a multi-channel time series into LSL. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/SendData.py>`__
+  * `Receiving a multi-channel time series from LSL. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/ReceiveData.py>`__
 
 The following examples show how to send and receive data in chunks, which can be more convenient. The data sender also demonstrates how to attach meta-data to the stream.
-  * `Sending a multi-channel time series in chunks. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/SendDataAdvanced.py>`__
-  * `Receiving a multi-channel time series in chunks. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/ReceiveDataInChunks.py>`__
+  * `Sending a multi-channel time series in chunks. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/SendDataAdvanced.py>`__
+  * `Receiving a multi-channel time series in chunks. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/ReceiveDataInChunks.py>`__
 
 These examples show a special-purpose use case that is mostly relevant for stimulus-presentation programs or other applications that want to emit 'event' markers or other application state. The stream here is single-channel and has irregular sampling rate, but the value per channel is a string:
-  * `Sending string-formatted irregular streams. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/SendStringMarkers.py>`__
-  * `Receiving string-formatted irregular streams. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/ReceiveStringMarkers.py>`__
+  * `Sending string-formatted irregular streams. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/SendStringMarkers.py>`__
+  * `Receiving string-formatted irregular streams. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/ReceiveStringMarkers.py>`__
 
 The last example shows how to attach properly formatted meta-data to a stream, and how to read it out again at the receiving end. While meta-data is strictly optional, it is very useful to make streams self-describing. LSL has adopted the convention to name meta-data fields according to the XDF file format specification whenever the content type matches (for example EEG, Gaze, MoCap, VideoRaw, etc); the spec is `here <https://github.com/sccn/xdf/wiki/Meta-Data>`__. Note that some older example programs (SendData/ReceiveData) predate this convention and name the channels inconsistently.
-  * `Handling stream meta-data. <https://github.com/labstreaminglayer/liblsl-Python/tree/master/pylsl/examples/HandleMetadata.py>`__
+  * `Handling stream meta-data. <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/HandleMetadata.py>`__
 
 MATLAB Example Programs: Basic to Advanced
 ******************************************
@@ -128,7 +128,7 @@ These examples show a special-purpose use case that is mostly relevant for stimu
   * `Sending string-formatted irregular streams. <https://github.com/labstreaminglayer/liblsl-Java/tree/master/src/examples/SendStringMarkers.java>`__
   * `Receiving string-formatted irregular streams. <https://github.com/labstreaminglayer/liblsl-Java/tree/master/src/examples/ReceiveStringMarkers.java>`__
 
-The last example shows how to attach properly formatted meta-data to a stream, and how to read it out again at the receiving end. While meta-data is strictly optional, it is very useful to make streams self-describing. LSL has adopted the convention to name meta-data fields according to the XDF file format specification whenever the content type matches (for example EEG, Gaze, MoCap, VideoRaw, etc); the spec is `here <http://code.google.com/p/xdf/wiki/MetaData>`__. Note that some older example programs (SendData/ReceiveData) predate this convention and name the channels inconsistently.
+The last example shows how to attach properly formatted meta-data to a stream, and how to read it out again at the receiving end. While meta-data is strictly optional, it is very useful to make streams self-describing. LSL has adopted the convention to name meta-data fields according to the XDF file format specification whenever the content type matches (for example EEG, Gaze, MoCap, VideoRaw, etc); the spec is `here <https://github.com/sccn/xdf/wiki/Meta-Data>`__. Note that some older example programs (SendData/ReceiveData) predate this convention and name the channels inconsistently.
   * `Handling stream meta-data. <https://github.com/labstreaminglayer/liblsl-Java/tree/master/src/examples/HandleMetaData.java>`__
 
 C# Example Programs: Basic to Advanced

--- a/docs/dev/lib_dev.rst
+++ b/docs/dev/lib_dev.rst
@@ -210,7 +210,7 @@ Conan
 
 Conan packages are managed in the `conan-io/conan-center-index <https://github.com/conan-io/conan-center-index>`_ repository on GitHub
 and changes or additions are submitted in the form of pull requests.
-For a general overview of the Conan package maintenance process, see `Adding Packages to ConanCenter <https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md>`_.
+For a general overview of the Conan package maintenance process, see `Adding Packages to ConanCenter <https://github.com/conan-io/conan-center-index/tree/master/docs/adding_packages>`_.
 
 The liblsl port is maintained at https://github.com/conan-io/conan-center-index/tree/master/recipes/liblsl.
 

--- a/docs/info/faqs.rst
+++ b/docs/info/faqs.rst
@@ -26,7 +26,7 @@ lsl_local_clock()
 What clock does LSL use? / 
 How do I relate LSL's :cpp:func:`lsl_local_clock()` to my wall clock?
 
-LSL's :cpp:func:`lsl_local_clock()` function uses `std::chrono::steady_clock <https://en.cppreference.com/w/cpp/chrono/steady_clock>`_::now().time_since_epoch(). This returns the number of seconds from an arbitrary starting point. The starting point is platform-dependent -- it may be close to UNIX time, or the last reboot -- and LSL timestamps cannot be transformed naively to wall clock time without special effort.
+LSL's :cpp:func:`lsl_local_clock()` function uses `std::chrono::steady_clock <https://en.cppreference.com/cpp/chrono/steady_clock>`_::now().time_since_epoch(). This returns the number of seconds from an arbitrary starting point. The starting point is platform-dependent -- it may be close to UNIX time, or the last reboot -- and LSL timestamps cannot be transformed naively to wall clock time without special effort.
 For more information, see the :doc:`../info/time_synchronization` under the "Manual Synchronization" section.
 
 Latency
@@ -255,7 +255,7 @@ how to name the file, i.e. :file:`lsl.dll` for Windows,
 :file:`liblsl.so` for Linux and Android and
 :file:`liblsl.dylib` for MacOS / OS X.
 
-The `liblsl release page <http://github.com/sccn/liblsl/releases/latest>`_
+The `liblsl release page <https://github.com/sccn/liblsl/releases>`_
 has multiple packages, generally called
 :file:`liblsl-{version}-{system}.{extension}`, e.g. 
 :file:`liblsl-1.13.1-Linux64-bionic.deb` with the 64 bit Ubuntu Linux 18.04

--- a/docs/info/intro.rst
+++ b/docs/info/intro.rst
@@ -8,7 +8,7 @@ The lab streaming layer (LSL) is a system for the unified collection of measurem
 
 The **LSL distribution** consists of the core library and a suite of tools built on top of the library.
 
-The core transport library is `liblsl <https://github.com/labstreaminglayer/liblsl/>`__ and its language interfaces (`C <https://github.com/sccn/liblsl/>`__, `C++ <https://github.com/sccn/liblsl/>`__, `Python <https://github.com/labstreaminglayer/liblsl-Python/>`__, `Java <https://github.com/labstreaminglayer/liblsl-Java/>`__, `C# <https://github.com/labstreaminglayer/liblsl-Csharp/>`__, `MATLAB <https://github.com/labstreaminglayer/liblsl-Matlab/>`__).
+The core transport library is `liblsl <https://github.com/labstreaminglayer/liblsl/>`__ and its language interfaces (`C <https://github.com/sccn/liblsl/>`__, `C++ <https://github.com/sccn/liblsl/>`__, `Python <https://github.com/labstreaminglayer/pylsl/>`__, `Java <https://github.com/labstreaminglayer/liblsl-Java/>`__, `C# <https://github.com/labstreaminglayer/liblsl-Csharp/>`__, `MATLAB <https://github.com/labstreaminglayer/liblsl-Matlab/>`__).
 The library is general-purpose and cross-platform (OS Support: Win / Linux / MacOS / `Android <https://github.com/labstreaminglayer/liblsl-Android/>`__ / iOS; Architecture Support: x86 / amd64 / arm).
 
 The suite of tools includes a :lslrepo:`recording program <LabRecorder>`,
@@ -17,7 +17,7 @@ a range of acquisition hardware (see :doc:`supported_devices`) available on the
 lab network (for example audio, EEG, or motion capture).
 
 There is an
-`intro lecture/demo on LSL <http://www.youtube.com/watch?v=Y1at7yrcFW0>`__
+`intro lecture/demo on LSL <https://www.youtube.com/watch?v=Y1at7yrcFW0>`__
 (part of an online course on EEG-based brain-computer interfaces).
 
 Streaming Layer API

--- a/docs/info/matlab_example_with_muse.rst
+++ b/docs/info/matlab_example_with_muse.rst
@@ -2,7 +2,7 @@
 
 This is the series of steps to connect with the Muse.
 
-1. Download the Muse SDK from http://developer.choosemuse.com
+1. Download the Muse SDK from https://choosemuse.com/pages/developers
 2. Pair your computer with your Muse headset and connect to your Muse using muse-io (replace Muse-XXXX with the name of your Muse device as it shows in the Bluetooth settings)
     ``muse-io --device Muse-XXXX --lsl-eeg EEG``
 

--- a/docs/info/ovas.rst
+++ b/docs/info/ovas.rst
@@ -2,7 +2,7 @@
 
 OVAS
 ####
-The OpenViBE acquisition server (OVAS) is an open-source program that is part of the OpenViBE distribution and OpenViBE project (http://openvibe.inria.fr/) developed at INRIA. The OVAS supports a wide range of EEG hardware by itself, and is almost entirely complementary to what the LSL distribution is offering. Together both distributions cover the majority of the EEG market. As of version 1.0, the OVAS supports LSL as an output modality.
+The OpenViBE acquisition server (OVAS) is an open-source program that is part of the OpenViBE distribution and OpenViBE project (https://openvibe.inria.fr/) developed at INRIA. The OVAS supports a wide range of EEG hardware by itself, and is almost entirely complementary to what the LSL distribution is offering. Together both distributions cover the majority of the EEG market. As of version 1.0, the OVAS supports LSL as an output modality.
 
 To enable LSL output, click on Preferences in the OVAS application, check the box labeled LSL_EnableLSLOutput, and click apply. This setting will only have to be chosen once. After that, you connect to your EEG device as documented in the OpenVibe manuals., and click Play to enable streaming.
 
@@ -14,7 +14,7 @@ Problem with timestamps
 ***********************
 Once upon a time, and possibly still in the version you have, OVAS incorrectly overrides the timestamps.
 This makes it impossible to synchronize streams obtained from OVAS with streams obtained from non-OVAS sources.
-There is a solution. Follow this link for more info: http://openvibe.inria.fr/tracker/view.php?id=197
+There is a solution. Follow this link for more info: https://openvibe.inria.fr/tracker/view.php?id=197
 
 Minimizing Latency
 ******************

--- a/docs/info/supported_devices.rst
+++ b/docs/info/supported_devices.rst
@@ -15,7 +15,7 @@ The majority of EEG systems on the market are currently compatible with LSL.
 The following systems are supported by programs included in the LSL distribution (untested systems marked with a (u)):
   * `ABM B-Alert X4/X10/X24 wireless <https://github.com/labstreaminglayer/App-BAlertAthenaCLI>`__
   * `BioSemi Active II Mk1 and Mk2 <https://github.com/labstreaminglayer/App-BioSemi>`__
-  * `Blackrock Cerebus/NSP <https://github.com/labstreaminglayer/App-BlackrockTimestamps>`__ (timestamps only)
+  * `Blackrock Cerebus/NSP <https://github.com/labstreaminglayer/App-BlackrockCerebus>`__ (timestamps only)
   * `Cognionics dry/wireless <https://github.com/labstreaminglayer/App-Cognionics>`__
   * `EGI AmpServer <https://github.com/labstreaminglayer/App-EGIAmpServer>`__
   * `Enobio dry/wireless <https://github.com/labstreaminglayer/App-Enobio>`__ (u) (please use vendor-provided section)
@@ -36,15 +36,15 @@ The following devices support LSL via vendor-provided software:
   * `Brain Products BrainAmp series <https://github.com/brain-products/LSL-BrainAmpSeries>`__
   * `Brain Products LiveAmp <https://github.com/brain-products/LSL-LiveAmp/>`__
   * `BrainVision RDA client <https://github.com/brain-products/LSL-BrainVisionRDA>`__
-  * `Cognionics (all headsets) <http://www.cognionics.com/>`__
+  * `Cognionics (all headsets) <https://www.cgxsystems.com/>`__
   * `EB Neuro BE Plus LTM <http://www.ebneuro.biz/en/neurology/ebneuro/galileo-suite/be-plus-ltm>`__
   * `Emotiv Brainware (e.g. EPOC) via EmotivPRO <https://github.com/Emotiv/labstreaminglayer>`__
   * `IDUN Guardian via provided Python scripts <https://sdk-docs.idunguardian.com/examples.html#stream-data-to-lsl>`__
   * `mBrainTrain SMARTING <http://www.mbraintrain.com/smarting/>`__
-  * neuroelectrics `(Enobio <http://www.neuroelectrics.com/products/enobio/>`__, `StarStim <https://www.neuroelectrics.com/solutions/starstim>`__) via `NIC2 <https://www.neuroelectrics.com/solution/software-integrations/nic2>`__.
+  * neuroelectrics `(Enobio <https://www.neuroelectrics.com/products/enobio/>`__, `StarStim <https://www.neuroelectrics.com/solutions/starstim>`__) via `NIC2 <https://www.neuroelectrics.com/solution/software-integrations/nic2>`__.
   * `Mentalab Explore <https://github.com/Mentalab-hub/explorepy>`__
   * `Neuracle NeuroHub <https://github.com/neuracle/Neuracle.LSLSample>`__
-  * `OpenBCI (all headsets) <http://docs.openbci.com/software/06-labstreaminglayer>`__
+  * `OpenBCI (all headsets) <https://docs.openbci.com/Software/CompatibleThirdPartySoftware/LSL/>`__
   * `Starcat HackEEG Shield for Arduino <https://www.starcat.io/>`__
   * `TMSi APEX <https://www.tmsi.artinis.com/tmsi-python-library>`__
   * `TMSi SAGA <https://www.tmsi.artinis.com/tmsi-python-library>`__
@@ -53,7 +53,7 @@ The following are some of the devices we know about that support LSL natively th
   * `Bittium Faros <https://www.bittium.com/medical/cardiology>`__      
       * `Faros Streamer <https://github.com/bwrc/faros-streamer>`__
       * `Faros Streamer 2 <https://github.com/bwrc/faros-streamer-2>`__
-  * `InteraXon Muse <http://www.choosemuse.com/>`__
+  * `InteraXon Muse <https://choosemuse.com/>`__
       * :doc:`MU-01 - Muse - Released 2014 Example with Matlab <matlab_example_with_muse>`
       * `Muse (MU-02 2016) and Muse 2 (MU-03 2018) <https://github.com/alexandrebarachant/muse-lsl>`__
       * `Muse 2016, Muse 2, Muse S <https://github.com/kowalej/BlueMuse>`__
@@ -94,8 +94,8 @@ Various devices with ECG and/or EMG sensors are supported. Some of these have no
   * `Heart Rate Service bands <https://github.com/abcsds/HRBand-LSL>`__ (Many bluetooth HR bands such as the Polar H10)  
   * `RRStreamer (Android) <https://github.com/abcsds/RRStreamer>`__ (BLE Heart Rate bands such as the Polar H10, streamed from an Android phone with R-R intervals in milliseconds)
   * `Polar H10 ECG <https://github.com/markspan/PolarBLE?tab=readme-ov-file>`__  
-  * `Shimmer Examples (using LSL for C#) <https://github.com/ShimmerEngineering/liblsl-Csharp/tree/shimmer_dev/examples/SendData>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)
-  * `Shimmer Examples (using LSL for Java) <https://github.com/ShimmerEngineering/liblsl-Java/tree/shimmer_dev/src/examples>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)  
+  * `Shimmer Examples (using LSL for C#) <https://github.com/ShimmerResearch/liblsl-Csharp/tree/shimmer_dev/examples/SendData>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)
+  * `Shimmer Examples (using LSL for Java) <https://github.com/ShimmerResearch/liblsl-Java/tree/shimmer_dev/src/examples>`__ (ECG/EMG/GSR/Accelerometer/Gyroscope/Magnetometer/PPG/Temperature/etc)  
   * `TMSi SPIRE EMG <https://www.tmsi.artinis.com/tmsi-python-library>`__
   * `Zephyr BioHarness <https://github.com/labstreaminglayer/App-Zephyr>`__ (ECG/Respiration/Accelerometer)
 
@@ -104,7 +104,7 @@ Supported Eye Tracking Hardware
 Several eye tracking systems are currently supported by LSL and included in the distribution (untested systems marked with a (u)):
   * `7invensun Eye Tracker <https://github.com/FishBones-DIY/App-7invensun>`__
   * Custom 2-camera eye trackers (with some hacking)
-  * `EyeLogic <https://github.com/EyeLogicSolutions/EyeLogic-LSL>`__
+  * `EyeLogic <https://github.com/labstreaminglayer/EyeLogic-LSL>`__
   * :lslrepo:`EyeTechDS - VT3-Mini <EyeTechDS>`
   * Eye Tribe Tracker Pro
   * `HTC Vive Eye <https://github.com/mit-ll/Signal-Acquisition-Modules-for-Lab-Streaming-Layer>`__  
@@ -172,7 +172,7 @@ Miscellaneous Hardware
 The following miscellaneous hardware is supported:
   * :lslrepo:`Generic serial port <SerialPort>`
   * :lslrepo:`Measurement Computing DAQ <MeasurementComputing>`
-  * `biosignalsplux sensors using OpenSignals <https://www.biosignalsplux.com/index.php/software/apis>`__
+  * `biosignalsplux sensors using OpenSignals <https://support.pluxbiosignals.com/knowledge-base/biosignals-studio-lab-streaming-layer/>`__
   * :lslrepo:`Vernier Go Direct sensors <vernier>`
   * :lslrepo:`Nonin Xpod PPG  <nonin>`
   * `Tyromotion Amadeo Robot <https://github.com/pyreiz/ctrl-tyromotion>`__

--- a/docs/info/time_synchronization.rst
+++ b/docs/info/time_synchronization.rst
@@ -97,4 +97,4 @@ It is recommended that all LSL stream generators attach the following block to t
 Validation
 ==========
 
-To see the synchronization capabilities of LSL in action, see http://sccn.ucsd.edu/~mgrivich/Synchronization.html and especially http://sccn.ucsd.edu/~mgrivich/LSL_Validation.html.
+To see the synchronization capabilities of LSL in action, see https://sccn.ucsd.edu/download/mgrivich/LSL_Validation.html and especially https://sccn.ucsd.edu/download/mgrivich/LSL_Validation.html.

--- a/docs/info/viewers.rst
+++ b/docs/info/viewers.rst
@@ -31,24 +31,24 @@ Stand-alone online viewers:
 
     .. image:: ../images/SigVisualizer_demo.gif
     
-  * `PlotJuggler <https://github.com/facontidavide/PlotJuggler>`__ supporst LSL streams and other data sources.
+  * `PlotJuggler <https://github.com/PlotJuggler/PlotJuggler>`__ supporst LSL streams and other data sources.
   
   * `Open Ephys <https://open-ephys.org/gui>`__ via `OpenEphysLSL-Inlet Plugin <https://github.com/labstreaminglayer/OpenEphysLSL-Inlet>`__
   
   * Older `LSL-Inlet Plugin <https://github.com/tne-lab/LSL-inlet>`__
   
-  * The `python bindings <https://github.com/labstreaminglayer/liblsl-Python>`__ contain a
-    `very basic visualizer <https://github.com/labstreaminglayer/liblsl-Python/blob/master/pylsl/examples/ReceiveAndPlot.py>`__.
+  * The `python bindings <https://github.com/labstreaminglayer/pylsl>`__ contain a
+    `very basic visualizer <https://github.com/labstreaminglayer/pylsl/blob/main/src/pylsl/examples/ReceiveAndPlot.py>`__.
     To start it, install pylsl and pyqtgraph and run it as
     
     :command:`python -m pylsl.examples.ReceiveAndPlot`.
 
 
 Software suites/packages supporting online LSL visualization:
-  * `BCI2000 <http://bci2000.org/>`__
+  * `BCI2000 <https://www.bci2000.org/>`__
   * `Muse LSL <https://github.com/alexandrebarachant/muse-lsl>`__
   * `Neuropype <https://www.neuropype.io/>`__
-  * `OpenViBE <http://openvibe.inria.fr//>`__
+  * `OpenViBE <https://openvibe.inria.fr/>`__
 
 Offline Viewers
 **********************
@@ -57,7 +57,7 @@ The following software suites/packages support offline visualization of XDF file
   * `EEGLAB <https://sccn.ucsd.edu/eeglab/index.php>`__
   * `Neuropype <https://www.neuropype.io/>`__
   * `MNELab <https://github.com/cbrnr/mnelab>`__
-  * `MoBILAB <https://sccn.ucsd.edu/wiki/MoBILAB>`__
+  * `MoBILAB <https://github.com/sccn/mobilab/wiki>`__
   * `SigViewer <https://github.com/cbrnr/sigviewer>`__
   
 


### PR DESCRIPTION
This patch:

- Fix broken links of pylsl examples
- Update C and C++ example links (master branch -> main branch)
- http -> https